### PR TITLE
新規会員登録ページ、ログインページのviewを作成

### DIFF
--- a/app/assets/stylesheets/_component.scss
+++ b/app/assets/stylesheets/_component.scss
@@ -240,6 +240,7 @@ i {
   &:before {
     content: "\E016";
     @include icon;
+    font-size: 14px;
   }
 }
 .is-mail {
@@ -269,6 +270,40 @@ i {
   }
   &:focus {
     border-color: #0099e8;
+  }
+}
+.c-form_group {
+  margin: 40px 0 0;
+  &:first-child {
+    margin: 0;
+  }
+  &.is-hidden {
+    display: none;
+  }
+  label {
+    font-weight: 600;
+    + .c-textarea-default {
+      margin: 8px 0 0;
+    }
+  }
+  .c-input-default {
+    width: 100%;
+    margin: 8px 0 0;
+    + label {
+      margin: 24px 0 0;
+    }
+  }
+  .c-select-wrap {
+    margin: 8px 0 0;
+  }
+  select {
+    width: 100%;
+  }
+  .checkbox-default, .c-radio-default, .c-textarea-default {
+    margin: 16px 0 0;
+  }
+  .c-icon-arrow-bottom {
+    position: absolute;
   }
 }
 /* item */

--- a/app/assets/stylesheets/_p-user.scss
+++ b/app/assets/stylesheets/_p-user.scss
@@ -1,0 +1,67 @@
+/* login */
+.p-login_panel {
+  max-width: 456px;
+  margin: 0 auto;
+  background: #fff;
+
+  @include media-pc {
+    max-width: none;
+    width: 456px;
+  }
+  a {
+    display: block;
+    margin: 40px 0 0;
+  }
+}
+.p-login_no-account {
+  padding: 24px 32px;
+  text-align: center;
+
+  @include media-pc {
+    padding: 40px 64px;
+  }
+
+  p {
+    font-size: 14px;
+  }
+  a {
+    display: block;
+    margin: 8px 0 0;
+    border: 1px solid #0099e8;
+    background: #0099e8;
+    color: #fff;
+    line-height: 40px;
+    &:hover {
+      opacity: 1;
+      text-decoration: none;
+    }
+  }
+}
+.p-login_form-inner {
+  padding: 24px 32px;
+  border-top: 1px solid #eee;
+
+  @include media-pc {
+    padding: 32px 64px;
+  }
+  &.is-borderNone {
+    padding: 24px 32px;
+    border: 0;
+
+    @include media-pc {
+      padding: 24px 64px 32px;
+    }
+  }
+  .c-form_group {
+    margin: 24px 0 0;
+    &:first-child {
+      margin: 0;
+    }
+  }
+  .c-input-default {
+    margin: 0;
+  }
+}
+.p-login_submit {
+  margin: 24px 0 0;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,3 +7,4 @@
 @import "./animation";
 
 @import "./p-top";
+@import "./p-user";

--- a/app/controllers/viewtest_controller.rb
+++ b/app/controllers/viewtest_controller.rb
@@ -1,4 +1,7 @@
 class ViewtestController < ApplicationController
-  def index
-  end
+  layout "single", only: [:login, :signup]
+  def index; end
+  def login; end
+  def signup; end
+  def signup_registration; end
 end

--- a/app/views/layouts/_header_single.html.haml
+++ b/app/views/layouts/_header_single.html.haml
@@ -2,7 +2,7 @@
   %h1
     = link_to root_path do
       =image_tag 'common/logo.svg', alt: 'mercari'
-  -if current_page? viewtest_signup_registration_path
+  -if current_page? signup_registration_path
     %nav.l-progressBar.p-signup_bar
       %ol.l-clearfix
         %li.is-active

--- a/app/views/viewtest/login.html.haml
+++ b/app/views/viewtest/login.html.haml
@@ -1,0 +1,19 @@
+.l-single_wrapper
+  %main.l-single_main
+    .p-login_panel
+      .p-login_no-account
+        %p アカウントをお持ちでない方はこちら
+        = link_to '新規会員登録', new_user_registration_path
+      .p-login_form-inner
+        = button_tag 'Facebookでログイン', id: 'facebook-login', class: 'c-btn-default is-sns is-sns-facebook'
+        = button_tag 'Googleでログイン', id: 'google-login', class: 'c-btn-default is-sns is-sns-google'
+
+      = form_for 'resource', url: 'registration_path' do |f|
+        .p-login_form-inner
+          .c-form_group
+            = f.email_field :email, placeholder: 'メールアドレス', class: 'p-login_input-text c-input-default'
+          .c-form_group
+            = f.password_field :password, placeholder: 'パスワード', class: 'p-login_input-text c-input-default'
+          .c-form_group
+            = f.submit 'ログイン', class: 'p-login_submit c-btn-default is-red'
+          = link_to 'パスワードをお忘れの方', '/password/reset/start/'

--- a/app/views/viewtest/login.html.haml
+++ b/app/views/viewtest/login.html.haml
@@ -9,7 +9,7 @@
         = button_tag 'Googleでログイン', id: 'google-login', class: 'c-btn-default is-sns is-sns-google'
 
       = form_for 'resource', url: 'registration_path' do |f|
-        .p-login_form-inner
+        .p-login_form-inner.is-borderNone
           .c-form_group
             = f.email_field :email, placeholder: 'メールアドレス', class: 'p-login_input-text c-input-default'
           .c-form_group

--- a/app/views/viewtest/signup.html.haml
+++ b/app/views/viewtest/signup.html.haml
@@ -7,5 +7,5 @@
           = link_to new_user_registration_path, class: 'c-btn-default is-mail' do
             %i.c-icon-mail
             メールアドレスで登録
-          = button_tag 'Facebookでログイン', id: 'facebook-login', class: 'c-btn-default is-sns is-sns-facebook'
-          = button_tag 'Googleでログイン', id: 'google-login', class: 'c-btn-default is-sns is-sns-google'
+          = button_tag 'Facebookで登録', id: 'facebook-login', class: 'c-btn-default is-sns is-sns-facebook'
+          = button_tag 'Googleで登録', id: 'google-login', class: 'c-btn-default is-sns is-sns-google'

--- a/app/views/viewtest/signup.html.haml
+++ b/app/views/viewtest/signup.html.haml
@@ -1,0 +1,11 @@
+.l-single_wrapper
+  %main.l-single_main
+    %section.l-single_container
+      %h2.l-single_head 新規会員登録
+      .l-single_inner
+        .l-single_content
+          = link_to new_user_registration_path, class: 'c-btn-default is-mail' do
+            %i.c-icon-mail
+            メールアドレスで登録
+          = button_tag 'Facebookでログイン', id: 'facebook-login', class: 'c-btn-default is-sns is-sns-facebook'
+          = button_tag 'Googleでログイン', id: 'google-login', class: 'c-btn-default is-sns is-sns-google'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,11 @@
 Rails.application.routes.draw do
   root 'viewtest#index'
   devise_for :users
-
-  get '/viewtest/login', to: 'viewtest#login'
-  get '/viewtest/signup', to: 'viewtest#signup'
-  get '/viewtest/signup/registration', to: 'viewtest#signup_registration'
+  devise_scope :user do
+    get 'login', to: 'viewtest#login'
+    get 'signup', to: 'viewtest#signup'
+    get 'signup/registration', to: 'viewtest#signup_registration'
+  end
 
   resources :items do
     resources :reviews

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,10 @@ Rails.application.routes.draw do
   root 'viewtest#index'
   devise_for :users
 
+  get '/viewtest/login', to: 'viewtest#login'
+  get '/viewtest/signup', to: 'viewtest#signup'
+  get '/viewtest/signup/registration', to: 'viewtest#signup_registration'
+
   resources :items do
     resources :reviews
     resources :reports, only: [:create, :destroy]


### PR DESCRIPTION
# What
## 新規会員登録ページ、ログインページのviewを作成した

(1) viewtest#login, viewtest#signup,  viewtest#signup_registration　→　view仮作成用のコントローラーを作成
(2) routes.rb　→　ルーティングを追記
(3) view/viewtest/signup.html.haml, view/viewtest/login.html.haml　→　新規会員登録ページ、ログインページのhtmlを作成
(4) _p-user.scss　→　ページ固有のcssを作成。
(5) _component.scss　→　他ページと共通するコンポーネントのcssを作成

# Why
## アプリケーションに必須のため

(1) view作成担当者とバックエンド処理の担当者が異なり、並行して作業を進めているため、
　 仮にviewを作成・テストするためのコントローラー（viewtest）を作成している。

　また、ヘッダー、フッターがトップページと異なるため、子テンプレート（views/layouts/_single.html.haml）を当てている。
　 viewtest_controller.rb内の
　 layout "single", only: [:login, :signup]
　 は子テンプレートを当てるための記述だが、今後正式なコントローラーにviewを割当てた際は、コントローラー単位でテンプレートを当てるよう変更する予定。

　 viewtest#signup_registrationについては次のステップのページだが、
　子テンプレートのヘッダー（views/layouts/_header_single.html.haml）におけるプログレスバーの出し分けのテストのため作成した。
　今回作成した2ページにプログレスバーは存在しないため、非表示になるよう簡単な記述で設定しているが、次以降のページ作成時には、より多くのページに対応できるよう修正する予定。

(2)  上述のようにviewのテスト作成のため、仮のルート設定を行なっている。
(3) ひとまずviewの完成を目的としているため、すべて静的に作成している。フォームやリンク等も仮設定の状態としている。
　  また、reCAPTCHAによる認証部分は他ページにも存在するため、別に担当者を立てて対応することとし、今回のview作成では実装していない。
(4) ページ固有のCSSはこちらに記述する。p-はFLOCCSのCSS設計を取り入れたもので、各プロジェクト単位（user、mypage、buyなどの機能別）で別のファイルに分けることにした。また、各クラスの接頭辞に.p-をつける。
　 理由は各機能別に担当者を割り振っていることから、scssの衝突を最小限に防げると考えたため。
(5) 他ページと共通するコンポーネントは接頭辞.c-より始まる汎用クラスとしてこちらに追記した。

※その他、ブランチについては今後、本番環境（master）へのマージ、及びコードレビューの前に
ステージング環境でのデプロイ、確認を行いたいと考え、開発用ブランチ（develop）を作成している。
以降基本的にはdevelopブランチの下に各開発用ブランチを作成したいと考えている。
理由はデプロイ時にのみ発生するエラーが頻発することが予想され、masterへのプルリクエスト前にテストとしてデプロイしたいと考えたため。
また、基本的にコードレビューはdevelopからmasterへのマージの際に行いたいと考えているが、
現在の進行の都合上、view作成のタスクのみ例外的に各開発ブランチからdevelopへのマージの際にプルリクエストを出すことにした。

![localhost_3000_viewtest_login](https://user-images.githubusercontent.com/39951170/50675143-8016dc80-102f-11e9-9026-d4419ef3d7d0.png)
![localhost_3000_viewtest_signup](https://user-images.githubusercontent.com/39951170/50675153-8ad17180-102f-11e9-94d2-e199b26338df.png)