### PR TITLE
商品購入確認ページのviewを作成

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -1,3 +1,4 @@
+// common：modal
 $(document).ready(function() {
   $('.js-modal').magnificPopup({
     type: 'inline',
@@ -6,5 +7,12 @@ $(document).ready(function() {
   $('.c-modal').on('click', '.js-modal_btn-cancel', function (e) {
     e.preventDefault();
     $.magnificPopup.close();
+  });
+});
+// common：accordion
+$(function() {
+  $('.c-accordion_toggle').on('click', function() {
+    $(this).next('.c-accordion_child').slideToggle();
+    $(this).children('.c-accordion_icon').toggleClass('is-active');
   });
 });

--- a/app/assets/stylesheets/_component.scss
+++ b/app/assets/stylesheets/_component.scss
@@ -370,7 +370,44 @@ i {
     border-color: #0099e8;
   }
 }
-
+.c-radio-default {
+  position: relative;
+  input[type='radio'] {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    width: 20px;
+    height: 20px;
+    border: 1px solid #ccc;
+    border-radius: 50%;
+    background: #fff;
+    transition: all ease-out 0.3s;
+    cursor: pointer;
+    transform: translate(0, -50%);
+    &:checked {
+      border: 0;
+      border: 6px solid #0099e8;
+    }
+  }
+  label {
+    margin: 0 0 0 28px;
+    font-weight: 400;
+    cursor: pointer;
+  }
+}
+.radio-has-icon {
+  &:first-child {
+    margin: 0;
+  }
+  label {
+    margin: 0 0 0 4px;
+    vertical-align: middle;
+  }
+  input[type='radio'] {
+    left: auto;
+    right: 0;
+  }
+}
 .c-select-wrap {
   position: relative;
   background: #fff;
@@ -424,6 +461,17 @@ i {
   line-height: 14px;
   font-size: 12px;
   text-align: center;
+}
+.c-has-error-text {
+  color: #ea352d;
+  line-height: 1.5;
+  font-size: 14px;
+  li {
+    margin: 8px 0 0;
+  }
+  + label {
+    margin: 24px 0 0;
+  }
 }
 /* item */
 .c-items-box {
@@ -856,5 +904,21 @@ i {
     @include media-pc {
       font-size: 18px;
     }
+  }
+}
+/* accordion */
+.c-accordion {
+  &_toggle {
+    cursor: pointer;
+  }
+  &_icon {
+    transition: .4s;
+    transform-origin: center center;
+    &.is-active {
+      transform: rotate(-180deg) scale(1.4);
+    }
+  }
+  &_child {
+    display: none;
   }
 }

--- a/app/assets/stylesheets/_p-transaction.scss
+++ b/app/assets/stylesheets/_p-transaction.scss
@@ -1,0 +1,168 @@
+.p-buy_content {
+  margin: 40px 0 0;
+  padding: 24px 12.5% 0;
+  border-top: 1px solid #f5f5f5;
+  &:first-of-type {
+    margin: 0;
+  }
+  &:last-of-type {
+    padding: 40px 12.5%;
+  }
+}
+.p-buy_content-inner {
+  max-width: 320px;
+  margin: 0 auto;
+}
+.p-buy_item {
+  text-align: center;
+  img {
+    width: 148px;
+    &.is-higher-height {
+      width: auto;
+      max-height: 148px;
+    }
+  }
+  .is-red {
+    margin: 16px 0 0;
+  }
+}
+.p-buy_item-name {
+  margin: 8px 0 0;
+  font-size: 16px;
+  line-height: 1.5;
+}
+.p-buy_form {
+  p {
+    margin: 8px 0 0;
+    line-height: 1.5;
+  }
+  .c-btn-default {
+    margin: 8px 0 0;
+  }
+  .paypal-express-checkout-text {
+    width: 67px;
+    height: 23px;
+    font-size: 18px;
+    font-weight: 600;
+    text-align: left;
+    margin: 10px;
+    color: #179bd7;
+  }
+  .btn-paypal-express-checkout {
+    width: 100%;
+    height: 50px;
+    border: solid 3px #179bd7;
+    img {
+      width: 73px;
+      height: 20px;
+    }
+  }
+}
+.p-buy_price-ja {
+  margin: 16px 0 0;
+  font-size: 28px;
+  .p-item_shipping-fee {
+    margin: 0 0 0 8px;
+    font-size: 14px;
+    font-weight: 400;
+  }
+}
+.p-buy_accordion {
+  margin: 16px 0 0;
+  &.not-have {
+    background: #ccc;
+    .c-accordion_toggle {
+      cursor: default;
+    }
+  }
+  .c-accordion_toggle {
+    border: 1px solid #ccc;
+  }
+  .c-form_group {
+    margin: 0;
+  }
+  .c-accordion_toggle {
+    padding: 16px;
+  }
+  .c-accordion > ul {
+    padding: 24px 40px;
+    background: #fafafa;
+    text-align: left;
+  }
+  .c-icon-arrow-bottom {
+    font-size: 8px;
+  }
+}
+.p-buy_price-table {
+  display: table;
+  border-collapse: collapse;
+  width: 100%;
+  &:first-child {
+    margin: 8px 0 0;
+  }
+}
+.p-buy_price-row {
+  display: table-row;
+  border-top: 1px solid #ccc;
+  &:first-child {
+    border: 0;
+  }
+}
+.p-buy_price-cell {
+  display: table-cell;
+  padding: 16px 0;
+  text-align: right;
+  &:first-child {
+    text-align: left;
+  }
+  &.p-buy_accordion {
+    padding: 0;
+    .c-accordion_toggle {
+      padding: 16px 0;
+    }
+  }
+}
+.p-buy_you-pay {
+  font-size: 22px;
+
+  @include media-pc {
+    font-size: 28px;
+  }
+}
+.p-buy_user-info {
+  transition: all ease-out 0.3s;
+  &.disabled {
+    background: #888;
+    pointer-events: none;
+    a {
+      color: #333;
+    }
+  }
+  h3 {
+    margin: 40px 0 0;
+    font-size: 14px;
+    &:first-child {
+      margin: 0;
+    }
+  }
+  address {
+    display: block;
+  }
+}
+.p-buy_user-info-text {
+  margin: 8px 0 0;
+  font-size: 14px;
+  line-height: 1.4;
+}
+.p-buy_user-info-fix {
+  display: block;
+  text-align: right;
+  .c-icon-arrow-right {
+    margin: 0 0 0 8px;
+    font-size: 10px;
+    vertical-align: middle;
+  }
+  span {
+    vertical-align: middle;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,3 +10,4 @@
 @import "./p-user";
 @import "./p-sell";
 @import "./p-item";
+@import "./p-transaction";

--- a/app/controllers/viewtest_controller.rb
+++ b/app/controllers/viewtest_controller.rb
@@ -1,9 +1,10 @@
 class ViewtestController < ApplicationController
-  layout "single", only: [:login, :signup, :sell]
+  layout "single", only: [:login, :signup, :sell, :transaction_buy_id]
   def index; end
   def login; end
   def signup; end
   def signup_registration; end
   def sell; end
   def item_id; end
+  def transaction_buy_id; end
 end

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -2719,5 +2719,5 @@
               = link_to 'ログイン', user_session_path, class: 'l-header_btn is-red'
             %li
               = link_to '新規会員登録', '/signup', class: 'l-header_btn l-header_btn-signup'
--if current_page? item_id_path
+- if current_page? item_id_path
   = render 'layouts/breadcrumbs'

--- a/app/views/viewtest/index.html.haml
+++ b/app/views/viewtest/index.html.haml
@@ -33,9 +33,9 @@
               = image_tag 'common/app-store.svg'
             = link_to '#' do
               = image_tag 'common/google-play.svg'
-      = link_to '', 'dummy', class: 'p-top_banner p-top_banner-new-register'
-      = link_to '', 'dummy', class: 'is-disable', class: 'p-top_banner p-top_banner-kusanagi-xmas'
-      = link_to '', 'dummy', class: 'p-top_banner p-top_banner-welcome'
+      = link_to '', '#', class: 'p-top_banner p-top_banner-new-register'
+      = link_to '', '#', class: 'is-disable', class: 'p-top_banner p-top_banner-kusanagi-xmas'
+      = link_to '', '#', class: 'p-top_banner p-top_banner-welcome'
     %section.p-top_pickup
       %h2.p-top_pickup-head ピックアップカテゴリー
       %section.c-items-box_container.l-clearfix

--- a/app/views/viewtest/transaction_buy_id.html.haml
+++ b/app/views/viewtest/transaction_buy_id.html.haml
@@ -1,0 +1,71 @@
+.l-single_wrapper
+  %section.l-single_container.p-buy_item-container
+    %h2.l-single_head 購入を確定しますか？
+    %section.p-buy_content.p-buy_item
+      .p-buy_content-inner
+        %h3.p-buy_item-image
+          = image_tag 'common/img_dummy.jpg', class: 'is-higher-height'
+        %p.p-buy_item-name.u-fwBold テキストテキスト商品名が入る
+        = form_for '#', html: {class: 'p-buy_form'} do |f|
+          %p.p-buy_price-ja.u-fwBold
+            ¥ 500
+            %span.p-item_shipping-fee.u-fw14.u-fwBold 送料込み
+          %ul.p-buy_accordion
+            %li.c-accordion
+              .c-accordion_toggle
+                ポイントを使う
+                %i.c-icon-arrow-bottom.c-accordion_icon
+              %ul.c-accordion_child
+                %li.u-fwBold 所持ポイント: P 500
+                %li.c-form_group
+                  .c-radio-default
+                    %label
+                      = f.radio_button 'consume_point_radio', 'none'
+                      ポイントを使わない
+                  .c-radio-default
+                    %label
+                      = f.radio_button 'consume_point_radio', 'all'
+                      すべてのポイントを使う
+                      %br
+                      P 500
+                  .c-radio-default
+                    %label
+                      = f.radio_button 'consume_point_radio', 'partial'
+                      一部のポイントを使う
+                  = f.number_field :point, placeholder: '使うポイントを入力', class: 'c-input-default'
+          %ul.p-buy_price-table
+            %li.p-buy_price-row.p-buy_you-pay.u-fwBold
+              .p-buy_price-cell 支払い金額
+              .p-buy_price-cell
+                %span ¥ 500
+          -# エラーメッセージ　配送先か支払い方法が未登録の際に表示
+          -# %p.c-has-error-text
+          -#   配送先と支払い方法の入力を完了してください。
+          = button_tag '購入する', class: 'c-btn-default is-red u-fzBold'
+    %section.p-buy_content.p-buy_user-info
+      .p-buy_content-inner
+        %h3 配送先
+        %address.p-buy_user-info-text
+          〒651-0091
+          %br
+          兵庫県 神戸市中央区若菜通
+          ４ー２４
+          セントラルハイツ三宮東601
+          %br
+          斎寺 亜斗
+        %p.p-buy_user-info-text
+        = link_to '#', class: 'p-buy_user-info-fix' do
+          %span 変更する
+          %i.c-icon-arrow-right
+    %section.p-buy_content.p-buy_user-info
+      .p-buy_content-inner
+        %h3 支払い方法
+        %p.p-buy_user-info-text
+          ************9889
+          %br
+          09 / 22
+        %figure
+          = image_tag 'card/master-card.svg', alt: 'master-card', width: '34', height: '20'
+        = link_to '#', class: 'p-buy_user-info-fix' do
+          %span 変更する
+          %i.c-icon-arrow-right

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
   get 'sell', to: 'viewtest#sell'
   get 'item-id', to: 'viewtest#item_id'
+  get 'transaction/buy/id', to: 'viewtest#transaction_buy_id'
 
   resources :items do
     resources :reviews


### PR DESCRIPTION
# What
## 商品購入確認ページのviewを作成した

(1) viewtest#transaction_buy_id　→　view仮作成用のコントローラーを作成
(2) view/viewtest/transaction_buy_id.html.haml　→　商品詳細ページのhtmlを作成
(3) _p-transaction.scss　→　ページ固有のcssを作成
(4) _component.scss　→　他ページと共通するコンポーネントを追記
(5) common.js　→　アコーディオンのjsを追記

# Why
## アプリケーションに必須のため

(1) 現在 view作成担当者とバックエンド処理の担当者が異なるため、
　 仮にviewを作成・テストするためのコントローラー（viewtest）を作成している。
(2) ひとまずviewの完成を目的としているため、すべて静的に作成している。リンク等も仮設定の状態としている。
(3) ページ固有のCSSはこちらに記述する。
(4) 他ページと共通するコンポーネントは接頭辞.c-より始まる汎用クラスとしてこちらに記述した。
(5) 他ページでも使用されるアコーディオンのjsは、共通で使用するcommon.jsに記述した。

![localhost_3000_transaction_buy_id](https://user-images.githubusercontent.com/39951170/50732548-9011f600-11c0-11e9-8f0f-37a94feb11f1.png)
![fefceafd6cf414cb9a05e7de27eedfc0](https://user-images.githubusercontent.com/39951170/50732558-ba63b380-11c0-11e9-8b73-d777d6760e54.gif)
