### PR TITLE
ログアウトページのviewを作成

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -1,5 +1,5 @@
-// common：modal
-$(document).ready(function() {
+$(function() {
+  // common：modal
   $('.js-modal').magnificPopup({
     type: 'inline',
     showCloseBtn: false
@@ -8,11 +8,19 @@ $(document).ready(function() {
     e.preventDefault();
     $.magnificPopup.close();
   });
-});
-// common：accordion
-$(function() {
+  // common：accordion
   $('.c-accordion_toggle').on('click', function() {
     $(this).next('.c-accordion_child').slideToggle();
     $(this).children('.c-accordion_icon').toggleClass('is-active');
+  });
+  // common：navi active
+  $('.js-active a').each(function(){
+    var url = window.location.pathname;
+    var navilink = $(this).attr('href');
+    if(url.match(navilink)) {
+        $(this).addClass('is-active');
+    } else {
+        $(this).removeClass('is-active');
+    }
   });
 });

--- a/app/assets/stylesheets/_p-mypage.scss
+++ b/app/assets/stylesheets/_p-mypage.scss
@@ -1,0 +1,67 @@
+.p-mypage_nav_list {
+  li {
+    border-top: 1px solid #eee;
+    &:first-child {
+      border: 0;
+    }
+  }
+  a:hover {
+    background: #fafafa;
+    text-decoration: none;
+    opacity: 1;
+    .c-icon-arrow-right {
+      transform: translate(4px, -50%);
+      color: #333;
+    }
+  }
+}
+.p-mypage_nav_list-item {
+  position: relative;
+  display: block;
+  min-height: 48px;
+  padding: 16px;
+  background: #fff;
+  color: #333;
+  &.is-active {
+    background: #eee;
+    font-weight: 600;
+    .c-icon-arrow-right {
+      color: #333;
+    }
+    &:hover {
+      background: #eee;
+    }
+  }
+  .c-icon-arrow-right {
+    position: absolute;
+    top: 50%;
+    right: 16px;
+    color: #ccc;
+    transform: translate(0, -50%);
+    transition: all ease-out 0.2s;
+  }
+}
+.p-mypage_nav_number {
+  position: absolute;
+  top: 50%;
+  right: 32px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #ea352d;
+  text-align: center;
+  line-height: 24px;
+  color: #fff;
+  transform: translate(0, -50%);
+}
+.p-mypage_nav_head {
+  margin: 40px 4% 0;
+  font-size: 16px;
+
+  @include media-pc {
+    margin: 40px 0 0;
+  }
+  + .p-mypage_nav_list {
+    margin: 8px 0 0;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,3 +11,4 @@
 @import "./p-sell";
 @import "./p-item";
 @import "./p-transaction";
+@import "./p-mypage";

--- a/app/controllers/viewtest_controller.rb
+++ b/app/controllers/viewtest_controller.rb
@@ -1,5 +1,6 @@
 class ViewtestController < ApplicationController
   layout "single", only: [:login, :signup, :sell, :transaction_buy_id]
+  layout "mypage", only: [:logout]
   def index; end
   def login; end
   def signup; end
@@ -7,4 +8,5 @@ class ViewtestController < ApplicationController
   def sell; end
   def item_id; end
   def transaction_buy_id; end
+  def logout; end
 end

--- a/app/controllers/viewtest_controller.rb
+++ b/app/controllers/viewtest_controller.rb
@@ -1,6 +1,5 @@
 class ViewtestController < ApplicationController
   layout "single", only: [:login, :signup, :sell, :transaction_buy_id]
-  layout "mypage", only: [:logout]
   def index; end
   def login; end
   def signup; end
@@ -8,5 +7,7 @@ class ViewtestController < ApplicationController
   def sell; end
   def item_id; end
   def transaction_buy_id; end
-  def logout; end
+  def logout
+    render :logout, layout: "mypage"
+  end
 end

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -2719,5 +2719,5 @@
               = link_to 'ログイン', user_session_path, class: 'l-header_btn is-red'
             %li
               = link_to '新規会員登録', '/signup', class: 'l-header_btn l-header_btn-signup'
--if current_page? item_id_path
+- if current_page? item_id_path
   = render 'layouts/breadcrumbs'

--- a/app/views/layouts/_side_mypage.html.haml
+++ b/app/views/layouts/_side_mypage.html.haml
@@ -1,0 +1,101 @@
+.l-side
+  %nav.p-mypage_nav.js-active
+    %ul.p-mypage_nav_list
+      %li
+        = link_to '/mypage/', class: 'p-mypage_nav_list-item' do
+          マイページ
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/mypage/notification/', class: 'p-mypage_nav_list-item' do
+          お知らせ
+          %span.p-mypage_nav_number
+            34
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/mypage/todo/', class: 'p-mypage_nav_list-item' do
+          やることリスト
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/mypage/like/history/', class: 'p-mypage_nav_list-item' do
+          いいね！一覧
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/sell/', class: 'p-mypage_nav_list-item' do
+          出品する
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/mypage/listings/listing/', class: 'p-mypage_nav_list-item' do
+          出品した商品 - 出品中
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/mypage/listings/in_progress/', class: 'p-mypage_nav_list-item' do
+          出品した商品 - 取引中
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/mypage/listings/completed/', class: 'p-mypage_nav_list-item' do
+          出品した商品 - 売却済み
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/mypage/purchase/', class: 'p-mypage_nav_list-item' do
+          購入した商品 - 取引中
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/mypage/purchased/', class: 'p-mypage_nav_list-item' do
+          購入した商品 - 過去の取引
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/mypage/news/', class: 'p-mypage_nav_list-item' do
+          ニュース一覧
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/mypage/review/history/', class: 'p-mypage_nav_list-item' do
+          評価一覧
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/help_center/', class: 'p-mypage_nav_list-item' do
+          ガイド
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/mypage/support/', class: 'p-mypage_nav_list-item' do
+          お問い合わせ
+          %i.c-icon-arrow-right
+    %h3.p-mypage_nav_head 売上・ポイント
+    %ul.p-mypage_nav_list
+      %li
+        = link_to '/mypage/sales/', class: 'p-mypage_nav_list-item' do
+          売上・振込申請
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/mypage/point/', class: 'p-mypage_nav_list-item' do
+          ポイント
+          %i.c-icon-arrow-right
+    %h3.p-mypage_nav_head 設定
+    %ul.p-mypage_nav_list
+      %li
+        = link_to '/mypage/profile/', class: 'p-mypage_nav_list-item' do
+          プロフィール
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/mypage/deliver_address/', class: 'p-mypage_nav_list-item' do
+          住所変更
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/mypage/card/', class: 'p-mypage_nav_list-item' do
+          支払い方法
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/mypage/email_password/', class: 'p-mypage_nav_list-item' do
+          メール/パスワード
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/mypage/identification/', class: 'p-mypage_nav_list-item' do
+          本人情報
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/mypage/sms_confirmation/', class: 'p-mypage_nav_list-item' do
+          電話番号の確認
+          %i.c-icon-arrow-right
+      %li
+        = link_to '/logout', class: 'p-mypage_nav_list-item' do
+          ログアウト
+          %i.c-icon-arrow-right

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -13,6 +13,8 @@
     .l-default-container
     - if content_for?(:single)
       = yield(:single)
+    - elsif content_for?(:mypage)
+      = yield(:mypage)
     - else
       = render 'layouts/header'
       = yield

--- a/app/views/layouts/mypage.html.haml
+++ b/app/views/layouts/mypage.html.haml
@@ -1,4 +1,4 @@
-- content_for(:single) do
+- content_for(:mypage) do
   = render 'layouts/header'
   = render 'layouts/breadcrumbs'
   %main.l-container.l-clearfix

--- a/app/views/layouts/mypage.html.haml
+++ b/app/views/layouts/mypage.html.haml
@@ -1,0 +1,8 @@
+- content_for(:single) do
+  = render 'layouts/header'
+  = render 'layouts/breadcrumbs'
+  %main.l-container.l-clearfix
+    = yield
+    = render 'layouts/side_mypage'
+  = render 'layouts/footer'
+= render template: 'layouts/application'

--- a/app/views/viewtest/logout.html.haml
+++ b/app/views/viewtest/logout.html.haml
@@ -1,0 +1,5 @@
+.l-content
+  .l-chapter-container
+    = form_for '#', url: '#', html: {class: 'l-single_inner'} do |f|
+      .l-single_content
+        = f.submit 'ログアウト', class: 'c-btn-default is-red'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     get 'login', to: 'viewtest#login'
     get 'signup', to: 'viewtest#signup'
     get 'signup/registration', to: 'viewtest#signup_registration'
+    get 'logout', to: 'viewtest#logout'
   end
 
   get 'sell', to: 'viewtest#sell'


### PR DESCRIPTION
# What
## ログアウトページのviewを作成した

(1) viewtest#logout　→　view仮作成用のコントローラーを作成
(2) view/viewtest/logout.html.haml　→　ログアウトページのhtmlを作成
(3) _p-mypage.scss　→　ページ固有のcssを作成
(4) view/layouts/_side_mypage.html.ham　→　マイページのサイドメニューをテンプレート化
(5) view/layouts/mypage.html.ham　→　マイページのレイアウトを子テンプレート化
(6) common.js　→　サイドメニューのアクティブ表示のjsを追記
![localhost_3000_logout](https://user-images.githubusercontent.com/39951170/50732892-71aef900-11c6-11e9-96e3-91555868a0d6.png)

# Why
## アプリケーションに必須のため

(1) view作成担当者とバックエンド処理の担当者が異なるため、
　 仮にviewを作成・テストするためのコントローラー（viewtest）を作成している。
　 マイページ用の子テンプレートをコントローラーで指定した。
(2) ひとまずviewの完成を目的としているため、すべて静的に作成している。リンク等も仮設定の状態としている。
(3) ページ固有のCSSはこちらに記述する。
(4) マイページのサイドメニューは共通するため、テンプレート化した。
(5) マイページのレイアウトをapplication.html.hamlの子テンプレートとして作成した
(6) 他ページでも使用されるアコーディオンのjsは、共通で使用するcommon.jsに記述した。