### PR TITLE
マイページのviewを作成

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -23,4 +23,12 @@ $(function() {
         $(this).removeClass('is-active');
     }
   });
+  // tab
+	$('.js-tab_menu li').click(function() {
+		var num = $(this).parent().children('li').index(this);
+		$(this).parent().each(function(){
+			$('>li',this).removeClass('is-active').eq(num).addClass('is-active');
+		});
+		$(this).parent().next().children('.js-tab_content').hide().eq(num).show();
+	}).first().click();
 });

--- a/app/assets/stylesheets/_component.scss
+++ b/app/assets/stylesheets/_component.scss
@@ -922,3 +922,44 @@ i {
     display: none;
   }
 }
+/* item list */
+.c-mypage_item-list {
+  li {
+    position: relative;
+    border-bottom: 1px solid #eee;
+    &:last-child {
+      border: 0;
+    }
+    &:first-child {
+      border-bottom: 1px solid #eee;
+    }
+    &.p-mypage_item-not-found {
+      border: 0;
+    }
+  }
+  a:hover {
+    background: #fafafa;
+    opacity: 1;
+    text-decoration: none;
+  }
+  img {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1;
+    width: 100%;
+    &.is-higher-height {
+      top: 50%;
+      transform: translate(0, -50%);
+    }
+    &.is-higher-width {
+      width: auto;
+      left: 50%;
+      right: auto;
+      height: 100%;
+      transform: translate(-50%, 0);
+    }
+  }
+}

--- a/app/assets/stylesheets/_p-mypage.scss
+++ b/app/assets/stylesheets/_p-mypage.scss
@@ -1,3 +1,4 @@
+/* side menu */
 .p-mypage_nav_list {
   li {
     border-top: 1px solid #eee;
@@ -63,5 +64,216 @@
   }
   + .p-mypage_nav_list {
     margin: 8px 0 0;
+  }
+}
+/* index */
+.p-mypage_user-icon {
+  position: relative;
+  height: 155px;
+  padding: 20px;
+  background: image-url("mypage/user-bg.jpg");
+  background-repeat: no-repeat;
+  background-size: cover;
+  text-align: center;
+
+  @include media-pc {
+    height: 200px;
+  }
+  > a {
+    display: block;
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 0;
+    transform: translate(0, -50%);
+    color: #333;
+  }
+  figure {
+    overflow: hidden;
+    width: 60px;
+    height: 60px;
+    margin: 0 auto;
+    border-radius: 50%;
+  }
+  h2 {
+    margin: 8px 0 0;
+    font-size: 14px;
+  }
+  + .p-mypage_tab-container {
+    margin: 0;
+  }
+  .user-official-badge {
+    margin: 8px 0 0;
+  }
+}
+.p-mypage_number {
+  margin: 8px 0 0;
+  font-size: 0;
+  div {
+    display: inline-block;
+    font-size: 14px;
+    + div {
+      margin: 0 0 0 16px;
+    }
+  }
+  span {
+    margin: 0 0 0 8px;
+    font-size: 16px;
+  }
+}
+.p-mypage_tab-container-notification-todo {
+  margin: 0;
+  background: #fff;
+}
+.p-mypage_tab-container {
+  margin: 40px 0 0;
+  background: #fff;
+  &:nth-of-type(1) {
+    margin: 0;
+  }
+  + .pager {
+    margin: 40px 0 0;
+  }
+}
+.p-mypage_tabs li {
+  width: 50%;
+}
+.p-mypage_tab-content .p-mypage_tab-content_tab-pane {
+  display: none;
+  &.is-active {
+    display: block;
+  }
+}
+.p-mypage_tab-head {
+  padding: 0 4%;
+  background: #fafafa;
+  font-size: 16px;
+  line-height: 72px;
+
+  @include media-pc {
+    padding: 0 16px;
+  }
+}
+.p-mypage_item-link {
+  display: block;
+  min-height: 80px;
+  padding: 16px;
+  color: #333;
+  figure {
+    position: relative;
+    overflow: hidden;
+    float: left;
+    width: 48px;
+    height: 48px;
+  }
+  time {
+    display: inline-block;
+    color: #888;
+    span {
+      vertical-align: middle;
+    }
+  }
+  .c-icon-time {
+    margin: 0 8px 0 0;
+  }
+  .c-icon-arrow-right {
+    position: absolute;
+    top: 50%;
+    right: 16px;
+    transform: translate(0, -50%);
+  }
+}
+.p-mypage_item-not-found {
+  padding: 160px 0 60px;
+  background: image-url("common/logo-gray-icon.svg");
+  background-repeat: no-repeat;
+  background-position: center 40px;
+  background-size: 78px 85px;
+  text-align: center;
+  font-size: 16px;
+  color: #ccc;
+}
+.p-mypage_listing-tabs, .p-mypage_tabs, .p-mypage_review-history-tabs {
+  border: 0;
+  background: #eee;
+  display: flex;
+}
+.p-mypage_listing-tabs li, .p-mypage_tabs li, .p-mypage_review-history-tabs li {
+  text-align: center;
+  vertical-align: top;
+  position: relative;
+  display: block;
+  color: #333;
+  line-height: 72px;
+  cursor: pointer;
+
+  h3 {
+    font-size: 16px;
+  }
+}
+.p-mypage_listing-tabs li.is-active, .p-mypage_tabs li.is-active, .p-mypage_review-history-tabs li.is-active {
+  background: #fff;
+  border-top: 2px solid #ea352d;
+}
+.p-mypage_listing-tabs .p-mypage_nav_number, .p-mypage_tabs .p-mypage_nav_number, .p-mypage_review-history-tabs .p-mypage_nav_number {
+  top: 16px;
+  right: 2px;
+}
+.p-mypage_item-body {
+  margin: 0 40px 0 68px;
+  .l-clearfix {
+    margin: 8px 0 0;
+  }
+  .l-flLeft {
+    width: 50%;
+
+    @include media-pc {
+      width: auto;
+    }
+  }
+  &.show-stock-item {
+    margin-right: 100px;
+  }
+}
+.p-mypage_item-text {
+  overflow: hidden;
+  display: block;
+  max-height: 4.4em;
+  text-overflow: ellipsis;
+  line-height: 1.5;
+}
+.p-mypage_item-status {
+  display: inline-block;
+  margin: 8px 0 0;
+  padding: 5px 6px;
+  border-radius: 2px;
+  font-size: 12px;
+  color: #fff;
+  &.is-action-required {
+    background: #ea352d;
+  }
+  &.is-awaiting {
+    background: #0099e8;
+  }
+  &.is-done {
+    background: #888;
+  }
+}
+.p-mypage_go-list {
+  padding: 16px;
+  a {
+    display: block;
+    height: 56px;
+    margin: 0 auto;
+    background: #eee;
+    color: #333;
+    line-height: 56px;
+    text-align: center;
+  }
+  .c-icon-arrow-right, span {
+    vertical-align: middle;
+  }
+  .c-icon-arrow-right {
+    margin: 0 0 0 8px;
   }
 }

--- a/app/views/layouts/_side_mypage.html.haml
+++ b/app/views/layouts/_side_mypage.html.haml
@@ -2,97 +2,97 @@
   %nav.p-mypage_nav.js-active
     %ul.p-mypage_nav_list
       %li
-        = link_to '/mypage/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage', class: 'p-mypage_nav_list-item' do
           マイページ
           %i.c-icon-arrow-right
       %li
-        = link_to '/mypage/notification/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage/notification', class: 'p-mypage_nav_list-item' do
           お知らせ
           %span.p-mypage_nav_number
             34
           %i.c-icon-arrow-right
       %li
-        = link_to '/mypage/todo/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage/todo', class: 'p-mypage_nav_list-item' do
           やることリスト
           %i.c-icon-arrow-right
       %li
-        = link_to '/mypage/like/history/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage/like/history', class: 'p-mypage_nav_list-item' do
           いいね！一覧
           %i.c-icon-arrow-right
       %li
-        = link_to '/sell/', class: 'p-mypage_nav_list-item' do
+        = link_to '/sell', class: 'p-mypage_nav_list-item' do
           出品する
           %i.c-icon-arrow-right
       %li
-        = link_to '/mypage/listings/listing/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage/listings/listing', class: 'p-mypage_nav_list-item' do
           出品した商品 - 出品中
           %i.c-icon-arrow-right
       %li
-        = link_to '/mypage/listings/in_progress/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage/listings/in_progress', class: 'p-mypage_nav_list-item' do
           出品した商品 - 取引中
           %i.c-icon-arrow-right
       %li
-        = link_to '/mypage/listings/completed/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage/listings/completed', class: 'p-mypage_nav_list-item' do
           出品した商品 - 売却済み
           %i.c-icon-arrow-right
       %li
-        = link_to '/mypage/purchase/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage/purchase', class: 'p-mypage_nav_list-item' do
           購入した商品 - 取引中
           %i.c-icon-arrow-right
       %li
-        = link_to '/mypage/purchased/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage/purchased', class: 'p-mypage_nav_list-item' do
           購入した商品 - 過去の取引
           %i.c-icon-arrow-right
       %li
-        = link_to '/mypage/news/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage/news', class: 'p-mypage_nav_list-item' do
           ニュース一覧
           %i.c-icon-arrow-right
       %li
-        = link_to '/mypage/review/history/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage/review/history', class: 'p-mypage_nav_list-item' do
           評価一覧
           %i.c-icon-arrow-right
       %li
-        = link_to '/help_center/', class: 'p-mypage_nav_list-item' do
+        = link_to '/help_center', class: 'p-mypage_nav_list-item' do
           ガイド
           %i.c-icon-arrow-right
       %li
-        = link_to '/mypage/support/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage/support', class: 'p-mypage_nav_list-item' do
           お問い合わせ
           %i.c-icon-arrow-right
     %h3.p-mypage_nav_head 売上・ポイント
     %ul.p-mypage_nav_list
       %li
-        = link_to '/mypage/sales/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage/sales', class: 'p-mypage_nav_list-item' do
           売上・振込申請
           %i.c-icon-arrow-right
       %li
-        = link_to '/mypage/point/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage/point', class: 'p-mypage_nav_list-item' do
           ポイント
           %i.c-icon-arrow-right
     %h3.p-mypage_nav_head 設定
     %ul.p-mypage_nav_list
       %li
-        = link_to '/mypage/profile/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage/profile', class: 'p-mypage_nav_list-item' do
           プロフィール
           %i.c-icon-arrow-right
       %li
-        = link_to '/mypage/deliver_address/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage/deliver_address', class: 'p-mypage_nav_list-item' do
           住所変更
           %i.c-icon-arrow-right
       %li
-        = link_to '/mypage/card/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage/card', class: 'p-mypage_nav_list-item' do
           支払い方法
           %i.c-icon-arrow-right
       %li
-        = link_to '/mypage/email_password/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage/email_password', class: 'p-mypage_nav_list-item' do
           メール/パスワード
           %i.c-icon-arrow-right
       %li
-        = link_to '/mypage/identification/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage/identification', class: 'p-mypage_nav_list-item' do
           本人情報
           %i.c-icon-arrow-right
       %li
-        = link_to '/mypage/sms_confirmation/', class: 'p-mypage_nav_list-item' do
+        = link_to '/mypage/sms_confirmation', class: 'p-mypage_nav_list-item' do
           電話番号の確認
           %i.c-icon-arrow-right
       %li

--- a/app/views/mypage/index.html.haml
+++ b/app/views/mypage/index.html.haml
@@ -1,0 +1,137 @@
+.l-content
+  %section.p-mypage_user-icon
+    = link_to '#' do
+      %figure
+        = image_tag 'common/member_photo_noimage_thumb.png', width: '60', height: '60'
+      %h2.u-fwBold atos
+      .p-mypage_number
+        %div
+          評価
+          %span.u-fwBold 0
+        %div
+          出品数
+          %span.u-fwBold 0
+  %section.p-mypage_tab-container-notification-todo
+    %ul.p-mypage_tabs.js-tab_menu
+      %li.is-active
+        %h3
+          お知らせ
+
+      %li
+        %h3
+          やることリスト
+
+    .p-mypage_tab-content
+      %ul#p-mypage_tab-notification.p-mypage_item-list.p-mypage_tab-content_tab-pane.js-tab_content.is-active
+        %li
+          = link_to '#', class: 'p-mypage_item-link js-modal' do
+            %figure
+              = image_tag 'common/mercari_profile.png'
+            .p-mypage_item-body
+              .p-mypage_item-text 【機能のお知らせ】商品出品時に画像を最大10枚登録できるようになりました！
+              %time
+                %i.c-icon-time
+                %span 1 日前
+            %i.c-icon-arrow-right
+        %li
+          = link_to '#', class: 'p-mypage_item-link js-modal' do
+            %figure
+              = image_tag 'common/mercari_profile.png'
+            .p-mypage_item-body
+              .p-mypage_item-text 7日後、クーポンの有効期限が切れます！タップして詳細を確認しましょう。
+              %time
+                %i.c-icon-time
+                %span 3 日前
+            %i.c-icon-arrow-right
+        %li
+          = link_to '#', class: 'p-mypage_item-link js-modal' do
+            %figure
+              = image_tag 'common/mercari_profile.png'
+            .p-mypage_item-body
+              .p-mypage_item-text アメリカン・エキスプレス（AMEX）のクレジットカード決済が利用可能になりました！
+              %time
+                %i.c-icon-time
+                %span 3 日前
+            %i.c-icon-arrow-right
+        %li
+          = link_to '/mypage/news/', class: 'p-mypage_item-link' do
+            %figure
+              = image_tag 'common/mercari_profile.png'
+            .p-mypage_item-body
+              .p-mypage_item-text 事務局から個別メッセージ「【P500進呈】ご登録ありがとうございます！メルカリでのお買い物をお楽しみください♪」
+              %time
+                %i.c-icon-time
+                %span 3 日前
+            %i.c-icon-arrow-right
+        %li
+          = link_to '#', class: 'p-mypage_item-link js-modal' do
+            %figure
+              = image_tag 'common/mercari_profile.png'
+            .p-mypage_item-body
+              .p-mypage_item-text 【あなたの本はいくらで売れる？】バーコードを読み取るだけのラクラク査定！
+              %time
+                %i.c-icon-time
+                %span 4 日前
+            %i.c-icon-arrow-right
+        %li.p-mypage_go-list
+          = link_to '一覧を見る', '/mypage/notification/'
+      %ul#p-mypage_tab-todo.p-mypage_item-list.p-mypage_tab-content_tab-pane.js-tab_content
+        %li.p-mypage_item-not-found.u-fwBold 現在、やることリストはありません
+  %section.p-mypage_tab-container
+    %h2.p-mypage_tab-head 購入した商品
+    %ul.p-mypage_tabs.js-tab_menu
+      %li.is-active
+        %h3
+          取引中
+      %li
+        %h3
+          過去の取引
+    .p-mypage_tab-content
+      %ul#p-mypage_tab-transaction-now.p-mypage_item-list.p-mypage_tab-content_tab-pane.js-tab_content.is-active
+        %li
+          = link_to '', class: 'p-mypage_item-link' do
+            %figure
+              = image_tag 'common/img_dummy.jpg'
+            .p-mypage_item-body
+              .p-mypage_item-text
+                「お得☆150枚 サンキューシール ありがとうシール」 を購入しました。
+                %span 取引が完了しました
+              .p-mypage_item-status.u-fwBold.is-action-required
+                受取評価待ち
+            %i.c-icon-arrow-right
+      %ul#p-mypage_tab-transaction-old.p-mypage_item-list.p-mypage_tab-content_tab-pane.js-tab_content
+        %li
+          = link_to '', class: 'p-mypage_item-link' do
+            %figure
+              = image_tag 'common/img_dummy.jpg'
+            .p-mypage_item-body
+              .p-mypage_item-text
+                「お得☆150枚 サンキューシール ありがとうシール」 を購入しました。
+                %span 取引が完了しました
+              .p-mypage_item-status.u-fwBold.is-done
+                取引完了
+            %i.c-icon-arrow-right
+        %li
+          = link_to '', class: 'p-mypage_item-link' do
+            %figure
+              = image_tag 'common/img_dummy.jpg'
+            .p-mypage_item-body
+              .p-mypage_item-text
+                「お得☆150枚 サンキューシール ありがとうシール」 を購入しました。
+                %span 取引が完了しました
+              .p-mypage_item-status.u-fwBold.is-done
+                取引完了
+            %i.c-icon-arrow-right
+        %li
+          = link_to '', class: 'p-mypage_item-link' do
+            %figure
+              = image_tag 'common/img_dummy.jpg'
+            .p-mypage_item-body
+              .p-mypage_item-text
+                「お得☆150枚 サンキューシール ありがとうシール」 を購入しました。
+                %span 取引が完了しました
+              .p-mypage_item-status.u-fwBold.is-done
+                取引完了
+            %i.c-icon-arrow-right
+        %li.p-mypage_go-list
+          = link_to '一覧を見る', '/mypage/purchased/'

--- a/app/views/mypage/index.html.haml
+++ b/app/views/mypage/index.html.haml
@@ -22,7 +22,7 @@
           やることリスト
 
     .p-mypage_tab-content
-      %ul#p-mypage_tab-notification.p-mypage_item-list.p-mypage_tab-content_tab-pane.js-tab_content.is-active
+      %ul#p-mypage_tab-notification.c-mypage_item-list.p-mypage_tab-content_tab-pane.js-tab_content.is-active
         %li
           = link_to '#', class: 'p-mypage_item-link js-modal' do
             %figure
@@ -75,7 +75,7 @@
             %i.c-icon-arrow-right
         %li.p-mypage_go-list
           = link_to '一覧を見る', '/mypage/notification/'
-      %ul#p-mypage_tab-todo.p-mypage_item-list.p-mypage_tab-content_tab-pane.js-tab_content
+      %ul#p-mypage_tab-todo.c-mypage_item-list.p-mypage_tab-content_tab-pane.js-tab_content
         %li.p-mypage_item-not-found.u-fwBold 現在、やることリストはありません
   %section.p-mypage_tab-container
     %h2.p-mypage_tab-head 購入した商品
@@ -87,7 +87,7 @@
         %h3
           過去の取引
     .p-mypage_tab-content
-      %ul#p-mypage_tab-transaction-now.p-mypage_item-list.p-mypage_tab-content_tab-pane.js-tab_content.is-active
+      %ul#p-mypage_tab-transaction-now.c-mypage_item-list.p-mypage_tab-content_tab-pane.js-tab_content.is-active
         %li
           = link_to '', class: 'p-mypage_item-link' do
             %figure
@@ -99,7 +99,7 @@
               .p-mypage_item-status.u-fwBold.is-action-required
                 受取評価待ち
             %i.c-icon-arrow-right
-      %ul#p-mypage_tab-transaction-old.p-mypage_item-list.p-mypage_tab-content_tab-pane.js-tab_content
+      %ul#p-mypage_tab-transaction-old.c-mypage_item-list.p-mypage_tab-content_tab-pane.js-tab_content
         %li
           = link_to '', class: 'p-mypage_item-link' do
             %figure

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,4 +30,6 @@ Rails.application.routes.draw do
       resources :lower_categories, only: [:show]
     end
   end
+
+  resources :mypage, only: [:index]
 end


### PR DESCRIPTION
# What
## マイページのviewを作成した

(1) mypage#index　→　mypageコントローラーにindexを作成
(2) view/mypage/index.html.haml　→　マイページのhtmlを作成
(3) _p-mypage.scss　→　ページ固有のcssを追記
(4) _conponent.scss　→　汎用クラスを追記
(5) view/layouts/_side_mypage.html.ham　→　サイドメニューのパスを修正
(6) common.js　→　タブのjsを追記

# Why
## アプリケーションに必須のため

(1) mypageコントローラーにindexを追加。
→すみません、間違えて当ブランチを切る前に作成してしまっていました、該当コミットは https://github.com/ato-s/freemarket_sample_36a/commit/23e83cb33e42cd02882290fc0a1f40678ad79f27
　mypageコントローラーに対しmypage用テンプレートを設定した。
(2) ひとまずviewの完成を目的としているため、すべて静的に作成している。リンク等も仮設定の状態としている。
(3) ページ固有のCSSはこちらに記述する。
(4) 一部、他と共通するcssがあったためこちらに記述した。
(5) 前に作成したナビゲーションのcurrent表示jsに対応するようパスを修正した。
(6) 他ページでも使用されるため、common.jsにタブ用jsを記述した。

![localhost_3000_mypage](https://user-images.githubusercontent.com/39951170/50734839-8a300b00-11e8-11e9-9b7b-35cc9412bba2.png)

![c718c0b58882d9261a5a0a0a856470a6](https://user-images.githubusercontent.com/39951170/50734856-c3687b00-11e8-11e9-9685-bd4c717d82b3.gif)
