### PR TITLE
プロフィール編集ページのviewを作成

### DIFF
--- a/app/assets/stylesheets/_p-mypage.scss
+++ b/app/assets/stylesheets/_p-mypage.scss
@@ -277,3 +277,34 @@
     margin: 0 0 0 8px;
   }
 }
+/* profile */
+.p-mypage_profile-icon {
+  padding: 72px 16px 24px;
+  background: image-url("mypage/user-bg.jpg");
+  background-repeat: no-repeat;
+  background-size: cover;
+  text-align: center;
+  font-size: 0;
+  figure {
+    display: inline-block;
+    overflow: hidden;
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    vertical-align: middle;
+  }
+  .c-input-default {
+    width: 220px;
+    margin: 0 0 0 8px;
+    vertical-align: middle;
+  }
+}
+.p-mypage_profile-content {
+  padding: 40px 16px;
+  .c-textarea-default {
+    min-height: 216px;
+  }
+  .is-red {
+    margin: 16px 0 0;
+  }
+}

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -1,6 +1,9 @@
 class MypageController < ApplicationController
   layout "mypage"
-  
+
   def index
+  end
+
+  def profile
   end
 end

--- a/app/views/mypage/profile.html.haml
+++ b/app/views/mypage/profile.html.haml
@@ -1,0 +1,11 @@
+.l-content
+  %section.l-chapter-container
+    %h2.l-chapter-head プロフィール
+    = form_for '#' do |f|
+      .p-mypage_profile-icon
+        %figure
+          = image_tag 'common/member_photo_noimage_thumb.png', width: '60', height: '60'
+        = f.text_field :params_name, placeholder: '例)AYA☆セール中', class: 'c-input-default'
+      .p-mypage_profile-content
+        = f.text_area :params_name, placeholder: '例）こんにちは☆ ご覧いただきありがとうございます！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取引できるよう心がけていますので、商品や発送方法などご質問がありましたらお気軽にどうぞ♪', class: 'c-textarea-default'
+        = f.submit '変更する', class: 'c-btn-default is-red'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,4 +32,5 @@ Rails.application.routes.draw do
   end
 
   resources :mypage, only: [:index]
+  get 'mypage/profile', to: 'mypage#profile'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,5 +32,4 @@ Rails.application.routes.draw do
   end
 
   resources :mypage, only: [:index]
-  get 'mypage/profile', to: 'mypage#profile'
 end


### PR DESCRIPTION
# What
## プロフィール編集ページのviewを作成した

(1) mypage#profile　→　mypageコントローラーにprofileを作成
(2) view/mypage/profile.html.haml　→　プロフィール編集ページのhtmlを作成
(3) _p-mypage.scss　→　ページ固有のcssを追記

# Why
## アプリケーションに必須のため

(1) mypageコントローラーにprofileを追加
　mypageコントローラーに対してmypage用テンプレートを設定している。
　ここの他、ログアウトページなども含め、マイページのレイアウトではあるが機能的に
　Userに置くべきか検討中のため、一旦仮置きの状態。
　サーバーサイドに進んだ際にUser担当者と相談予定。
(2) ひとまずviewの完成を目的としているため、すべて静的に作成している。リンクやフォーム等も仮設定の状態としている。
(3) マイページ固有のCSSはこちらに記述した。

※申し訳ありません、一部コミットが重複していますが同内容です。

![localhost_3000_mypage_profile](https://user-images.githubusercontent.com/39951170/50767679-1150b200-12c1-11e9-8421-7eb113460931.png)