### PR TITLE
カード情報ページのviewを作成

### DIFF
--- a/app/assets/stylesheets/_p-mypage.scss
+++ b/app/assets/stylesheets/_p-mypage.scss
@@ -308,3 +308,57 @@
     margin: 16px 0 0;
   }
 }
+/* payment */
+.p-mypage_payment-list li {
+  padding: 24px 0;
+  border-bottom: 1px solid #eee;
+  form {
+    position: relative;
+  }
+}
+.p-mypage_not-regist a {
+  display: block;
+  margin: 40px 0 0;
+  text-align: right;
+  span {
+    vertical-align: middle;
+  }
+  i {
+    vertical-align: middle;
+    &:first-child {
+      margin: 0 8px 0 0;
+    }
+    &:last-child {
+      margin: 0 0 0 8px;
+    }
+  }
+}
+.p-mypage_payment-num {
+    margin: 8px 0 0;
+    font-size: 16px;
+}
+.p-mypage_payment-remove {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 4px 6px;
+  background: #fff;
+  border-radius: 3px;
+  border: 1px solid #ea352d;
+  color: #ea352d;
+}
+.p-mypage_add-card {
+  padding: 24px 0;
+  border-bottom: 1px solid #eee;
+  a {
+    margin-bottom: 8px !important;
+    i {
+      margin-right: 16px;
+    }
+  }
+  small {
+    color: #888;
+    font-size: 12px;
+    font-weight: bold;
+  }
+}

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -9,4 +9,7 @@ class MypageController < ApplicationController
 
   def identification
   end
+
+  def card
+  end
 end

--- a/app/views/mypage/card.html.haml
+++ b/app/views/mypage/card.html.haml
@@ -1,0 +1,29 @@
+.l-content
+  %section.l-chapter-container
+    %h2.l-chapter-head 支払い方法
+    .l-single_inner
+      -# %section
+      -#   .l-single_content
+      -#     %h3.l-chapter-sub-head クレジットカード一覧
+      -#   %ul.settings-payment-list
+      -# %section.p-mypage_add-card
+      -#   .l-single_content
+      -#     = link_to '/mypage/card/create/', class: 'c-btn-default is-red c-submit_button' do
+      -#       %i.c-icon-card
+      -#       クレジットカードを追加する
+      -# 登録後はこちらを表示
+      %section
+        .l-single_content
+          %h3.l-chapter-sub-head クレジットカード一覧
+        %ul.p-mypage_payment-list
+          %li
+            = form_for '/', html: { class: 'l-single_content'} do |f|
+              %figure
+                = image_tag 'card/master-card.svg', alt: 'mastercard', width: '26', height: '20'
+              .p-mypage_payment-num ************9889
+              .p-mypage_payment-num 09 / 22
+              = button_tag '削除する', class: 'p-mypage_payment-remove'
+      .p-mypage_not-regist
+        = link_to '/help_center/category/6/', target: '_blank' do
+          %span 支払い方法について
+          %i.c-icon-arrow-right

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,4 +34,5 @@ Rails.application.routes.draw do
   resources :mypage, only: [:index]
   get 'mypage/profile', to: 'mypage#profile'
   get 'mypage/identification', to: 'mypage#identification'
+  get 'mypage/card', to: 'mypage#card'
 end


### PR DESCRIPTION
# What
## カード情報ページのviewを作成した

(1) mypage#card　→　mypageコントローラーにcardを作成
(2) view/mypage/card.html.haml　→　カード情報ページのhtmlを作成
(3) _p-mypage.scss　→　mypage固有のクラスとしてscssを追記

# Why
## アプリケーションに必須のため

(1) mypageコントローラーにcardを追加した、コントローラー単位でマイページ用レイアウトを設定している。
(2) ひとまずviewの完成を目的としているため、すべて静的に作成している。フォームやリンク等も仮設定の状態とした。
カードの登録状態によって表示が異なるため、カード登録時のコードはコメントアウトで記述した。
(3) FLOCSSの設計に基づき、各機能別にscssファイルを分け、接頭辞.p-から始まるプロジェクトレイヤーに置いている。
![localhost_3001_mypage_card](https://user-images.githubusercontent.com/39951170/51068887-326e2580-1668-11e9-9436-187e4d999303.png)
![localhost_3001_mypage_card 1](https://user-images.githubusercontent.com/39951170/51068888-3ef27e00-1668-11e9-9f02-45efb48b059d.png)
