### PR TITLE
カテゴリー一覧ページの実装

### DIFF
--- a/app/assets/stylesheets/_component.scss
+++ b/app/assets/stylesheets/_component.scss
@@ -972,6 +972,15 @@ i {
 .c-accordion {
   &_toggle {
     cursor: pointer;
+    .c-icon-plus {
+      position: absolute;
+      top: 50%;
+      right: 20px;
+      -webkit-transform: translate(0, -50%);
+      transform: translate(0, -50%);
+      color: #aaa;
+      font-size: 14px;
+    }
   }
   &_icon {
     transition: .4s;
@@ -984,6 +993,18 @@ i {
     display: none;
   }
 }
+.p-search_category-child {
+  + .c-icon-arrow-right {
+    position: absolute;
+    top: 50%;
+    right: 20px;
+    -webkit-transform: translate(0, -50%);
+    transform: translate(0, -50%);
+    color: #aaa;
+    font-size: 14px;
+  }
+}
+
 /* item list */
 .c-mypage_item-list {
   li {

--- a/app/assets/stylesheets/_p-search.scss
+++ b/app/assets/stylesheets/_p-search.scss
@@ -98,7 +98,7 @@
         line-height: 1.5;
       }
     }
-    &[class^="category-thumb"]:before {
+    &[class*="category-thumb"]:before {
       position: absolute;
       top: 50%;
       left: 15px;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :set_devise_layout, if: :devise_controller?
+  before_action :set_categories
 
   protected
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,6 +34,10 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def set_categories
+    @upper_categories = UpperCategory.eager_load(middle_categories: [:lower_categories])
+  end
+
   def production?
     Rails.env.production?
   end

--- a/app/controllers/upper_categories_controller.rb
+++ b/app/controllers/upper_categories_controller.rb
@@ -1,10 +1,8 @@
 class UpperCategoriesController < ApplicationController
   before_action :set_upper_category, only: [:show, :edit, :update, :destroy]
+  layout "include_breadcrumbs"
 
-  # GET /upper_categories
-  # GET /upper_categories.json
   def index
-    @upper_categories = UpperCategory.all
   end
 
   # GET /upper_categories/1

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -17,6 +17,8 @@
       = yield(:mypage)
     - elsif content_for?(:search)
       = yield(:search)
+    - elsif content_for?(:include_breadcrumbs)
+      = yield(:include_breadcrumbs)
     - else
       = render 'layouts/header'
       = yield

--- a/app/views/layouts/include_breadcrumbs.html.haml
+++ b/app/views/layouts/include_breadcrumbs.html.haml
@@ -1,0 +1,6 @@
+- content_for(:include_breadcrumbs) do
+  = render 'layouts/header'
+  = render 'layouts/breadcrumbs'
+  = yield
+  = render 'layouts/footer'
+= render template: 'layouts/application'

--- a/app/views/upper_categories/index.html.haml
+++ b/app/views/upper_categories/index.html.haml
@@ -1,19 +1,64 @@
-%h1 Listing upper_categories
-
-%table
-  %thead
-    %tr
-      %th
-      %th
-      %th
-
-  %tbody
-    - @upper_categories.each do |upper_category|
-      %tr
-        %td= link_to 'Show', upper_category
-        %td= link_to 'Edit', edit_upper_category_path(upper_category)
-        %td= link_to 'Destroy', upper_category, method: :delete, data: { confirm: 'Are you sure?' }
-
-%br
-
-= link_to 'New Upper category', new_upper_category_path
+.l-default-container
+  .category-index.l-single_container
+    .l-visibleSp
+      %section.p-search_category
+        .gray.l-clearfix
+          %h2 カテゴリー一覧
+        %nav
+          %ul.l-clearfix
+            - @upper_categories.each do |upper_category|
+              %li.c-accordion
+                %h3{class: "c-accordion_toggle category-thumb#{upper_category.id}"}
+                  %div
+                    = upper_category.name
+                  %i.c-icon-plus.c-accordion_icon
+                %ul.c-accordion_child
+                  %li
+                    = link_to '/upper_categories/#{upper_category.id}/' do
+                      .p-search_category-child
+                        すべて
+                      %i.c-icon-arrow-right
+                  - upper_category.middle_categories.each do |middle_category|
+                    %li.c-accordion
+                      = link_to '/middle_categories/#{middle_category.id}/', class: 'c-accordion_toggle' do
+                        .p-search_category-child
+                          = middle_category.name
+                        %i.c-icon-plus.c-accordion_icon
+                      %ul.c-accordion_child.p-search_category-subparent
+                        - middle_category.lower_categories.each do |lower_category|
+                          %li
+                            = link_to '/lower_categories/#{lower_category.id}/' do
+                              %i.c-icon-arrow-right
+                              .p-search_category-child.p-search_category-subchild
+                                = lower_category.name
+    .l-visiblePc
+      .gray
+        %h2 カテゴリー一覧
+      .category-list-nav.slide-nav-parent.u-taCenter.l-clearfix
+        - @upper_categories.each do |upper_category|
+          = link_to "#root_category-#{upper_category.id}", class: "u-bgWt category-root-category-link-name" do
+            = upper_category.name
+      .category-list-box
+        .category-list-individual-box.u-bgWt.l-clearfix
+          - @upper_categories.each do |upper_category|
+            .u-bgRd.u-clWt.category-list-individual-box-root-category-name
+              %h3#root_category-1
+                = upper_category.name
+            .category-list-individual-box-inner-box
+              %p
+                = link_to "/upper_categories/#{upper_category.id}/" do
+                  すべて
+              - upper_category.middle_categories.each do |middle_category|
+                .category-list-individual-box-sub-category-name
+                  %h4
+                    = middle_category.name
+                .l-clearfix.category-list-individual-box-sub-sub-category-box
+                  .category-list-individual-box-sub-sub-category-name
+                    %p
+                      = link_to "/middle_categories/#{middle_category.id}/" do
+                        すべて
+                  - middle_category.lower_categories.each do |lower_category|
+                    .category-list-individual-box-sub-sub-category-name
+                      %p
+                        = link_to "/lower_categories/#{lower_category.id}/" do
+                          = lower_category.name


### PR DESCRIPTION
# What
#  カテゴリー一覧ページの実装を行なった

(1) application_controller.rb#set_categories　→　カテゴリーをインスタンス変数に設定
(2) view/upper_categories/index.html.haml　→　カテゴリーページの一覧をループ処理に変更
(3) _component.scss, _p-search.scss　→　cssを修正

# Why
## ユーザビリティの向上、顧客の回遊性を高めるため

(1) 3階層のカテゴリーを設定。共通ヘッダー、及びその他のページでも使用することを想定し、application_controller.rbに記述した。
(2) 本サイトと同様に全てのカテゴリーの一覧を作成した。スマホとPCで別の記述になっている。viewはすでに作成済みのため、静的な記述をしていたカテゴリー一覧をループ処理に変更した。
仮置き状態だったディレクトリを移動したため、新規ファイルとなっている。
(3) CSSを修正。viewはすでに作成済みのため、スマホの修正のみ行なった。
view作成時のコミットはこちら
https://github.com/ato-s/freemarket_sample_36a/commit/72806395474948760ba9a62f43c27b5196275a3b
![localhost_3000_upper_categories_ 1](https://user-images.githubusercontent.com/39951170/51552372-cb484080-1eb3-11e9-9df1-30a540b7c628.png)
