### PR TITLE
パンくずリストの実装

### DIFF
--- a/app/controllers/lower_categories_controller.rb
+++ b/app/controllers/lower_categories_controller.rb
@@ -1,5 +1,6 @@
 class LowerCategoriesController < ApplicationController
   before_action :set_lower_category, only: [:show, :edit, :update, :destroy]
+  layout "include_breadcrumbs"
 
   # GET /lower_categories
   # GET /lower_categories.json

--- a/app/controllers/middle_categories_controller.rb
+++ b/app/controllers/middle_categories_controller.rb
@@ -1,5 +1,6 @@
 class MiddleCategoriesController < ApplicationController
   before_action :set_middle_category, only: [:show, :edit, :update, :destroy]
+  layout "include_breadcrumbs"
 
   # GET /middle_categories
   # GET /middle_categories.json

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -1,12 +1,2 @@
 %nav.l-breadCrumbs
-  %ul
-    %li
-      = link_to root_path do
-        %span メルカリ
-      %i.c-icon-arrow-right
-    %li
-      = link_to '#' do
-        %span テキスト
-      %i.c-icon-arrow-right
-    %li
-      %span テキスト
+  = breadcrumbs separator: "#{content_tag(:i, '', class: 'c-icon-arrow-right')}", style: :ul;

--- a/app/views/lower_categories/show.html.haml
+++ b/app/views/lower_categories/show.html.haml
@@ -1,6 +1,1 @@
-%p#notice= notice
-
-
-= link_to 'Edit', edit_lower_category_path(@lower_category)
-\|
-= link_to 'Back', lower_categories_path
+- breadcrumb :lower_categories, @lower_category

--- a/app/views/middle_categories/show.html.haml
+++ b/app/views/middle_categories/show.html.haml
@@ -1,6 +1,1 @@
-%p#notice= notice
-
-
-= link_to 'Edit', edit_middle_category_path(@middle_category)
-\|
-= link_to 'Back', middle_categories_path
+- breadcrumb :middle_categories, @middle_category

--- a/app/views/upper_categories/show.html.haml
+++ b/app/views/upper_categories/show.html.haml
@@ -1,6 +1,1 @@
-%p#notice= notice
-
-
-= link_to 'Edit', edit_upper_category_path(@upper_category)
-\|
-= link_to 'Back', upper_categories_path
+- breadcrumb :upper_categories, @upper_category

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,23 @@
+crumb :root do
+  link 'メルカリ', root_path
+end
+
+crumb :categories do
+  link 'カテゴリー一覧', upper_categories_path
+  parent :root
+end
+
+crumb :upper_categories do |upper_category|
+  link upper_category.name, upper_category_path(upper_category)
+  parent :categories, upper_category
+end
+
+crumb :middle_categories do |middle_category|
+  link middle_category.name, middle_category_path(middle_category)
+  parent :upper_categories, middle_category.upper_category
+end
+
+crumb :lower_categories do |lower_category|
+  link lower_category.name, lower_category_path(lower_category)
+  parent :middle_categories, lower_category.middle_category
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,17 +18,13 @@ Rails.application.routes.draw do
     resources :transaction_messages
   end
 
-
-
   resources :groups, only: [:show, :index] do
     resources :brands, only: [:show]
   end
 
-  resources :upper_categories, only: [:index, :show] do
-    resources :middle_categories, only: [:show] do
-      resources :lower_categories, only: [:show]
-    end
-  end
+  resources :upper_categories, only: [:index, :show]
+  resources :middle_categories, only: [:show]
+  resources :lower_categories, only: [:show]
 
   resource :transactions do
     resources :buys


### PR DESCRIPTION
# What
## パンくずリストの実装を行なった

(1) views/layouts/_breadcrumbs.html.haml　→　パンくずリストをパーツ化
(2) config/breadcrumbs.rb　→　パンくずリストの設定ファイルを作成
(3) lower_categories_controller.rb、
　  middle_categories_controller.rb　→　パンくずリスト付きレイアウトを各コントローラーに設定
(4) views/upper_categories/show.html.haml、
　  views/middle_categories/show.html.haml、
　  views/lower_categories/show.html.haml　→　パンくずリストの設定を各viewで呼びだすよう設定
(5) config/routes.rb　→　カテゴリーページのルーティングを変更

# Why
## ユーザビリティの向上、顧客の回遊性を高めるため。またSEO対策としても有効なため。

(1) パンくずリストをパーツ化し、子テンプレートで呼び出している。（子テンプレートは前回プルリクエスト作成時に追加している → views/layouts/include_breadcrumbs.html.haml、views/layouts/application.html.haml、該当コミットは https://github.com/ato-s/freemarket_sample_36a/pull/32/commits/75857ade9b3ea1242d0dde82d98b62d1c091073f）
(2) パンくずリストの設定ファイルを作成。まだ全てページの設定を行なってはいないが、テストとして階層化したカテゴリーページを作成した。
(3)パンくずリストが付いた子テンプレートを各コントローラーに設定した。
(4)パンくずリストの設定を各viewで呼びだす記述を追加した。
(5) 上記パンくずリストの設定やDB設計上、カテゴリーページのルーティングはネストする必要性がないと感じて当初設定していたルーティングのネストをやめている。ネストすると3階層に渡るパスの扱いが難しくなるため。
![localhost_3000_lower_categories_27 1](https://user-images.githubusercontent.com/39951170/51782178-63ba1b80-2167-11e9-9409-558f3a4f0a60.png)
