### PR TITLE
Develop-'adjustment between buy item and sell item'

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
 
 ### Association
 - belonsgs_to :user
+- has_many :deliverd_items, class_name: 'Item', foreign_key: 'shipping_address_id'
 
 
 # avatarsテーブル
@@ -199,12 +200,14 @@
 |lower_category_id|integer|null:false, foreign_key:true|
 |seller_id|integer|null:false, add_foreign_key :items, :users, column: :seller_id, index:true|
 |buyer_id|integer|add_foreign_key :items, :users, column: :buyer_id, index:true|
+|shipping_address_id|integer|add_foreign_key :items, :addresses, column: :shipping_address_id, index:true|
 
 ### Association
   belongs_to :brand, optional: true
   belongs_to :size, optional: true
   belongs_to :seller, class_name: 'User', foreign_key: 'seller_id', optional: true
   belongs_to :buyer, class_name: 'User', foreign_key: 'buyer_id', optional: true
+  belongs_to :shipping_address, class_name: 'Address', foreign_key: 'shipping_address_id', optional: true
   belongs_to :upper_category, optional: true
   belongs_to :middle_category, optional: true
   belongs_to :lower_category, optional: true

--- a/app/controllers/buys_controller.rb
+++ b/app/controllers/buys_controller.rb
@@ -1,29 +1,21 @@
 class BuysController < ApplicationController
+  before_action :set_item
+  before_action :confirm_item_seller_and_buyer
+  before_action :confirm_transaction_stage_under_sale
 
-before_action :set_item
-
-include Payjp_process
+  include Payjp_process
 
   def edit
-    if @item.transaction_stage == "sale"
-      @image = Picture.find(params[:item_id])
-      @address = Address.find_by(user_id: current_user.id)
-      @credit_data = show_customer_data
-    else
-      redirect_to root_path, alert: "既に販売済みの商品です"
-    end
+    @image = Picture.find(params[:item_id])
+    @address = Address.find_by(user_id: current_user.id)
+    @credit_data = show_customer_data
   end
 
   def update
-    if @item.transaction_stage == "sale"
-      @buy_price = @item.sell_price
-      @buyer_id = current_user.id
-      @transaction = @item.update(buy_price: @buy_price, buyer_id: @buyer_id,transaction_stage: 1)
-      create_charge(@buy_price)
-      redirect_to edit_item_buy_path
-    else
-      redirect_to root_path, alert: "既に販売済みの商品です"
-    end
+    @item.update(buy_params)
+    @payment = @item.buy_price - @item.discount_point
+    create_charge(@payment)
+    redirect_to edit_item_buy_path
   end
 
   private
@@ -31,5 +23,13 @@ include Payjp_process
   def set_item
     @item = Item.find(params[:item_id])
   end
-
+  def buy_params
+    params.require(:patch).permit(:discount_point, :shipping_address_id).merge(buyer_id: current_user.id, transaction_stage: "under_transaction")
+  end
+  def confirm_item_seller_and_buyer
+    redirect_to root_path, alert: "出品した商品を購入することはできません" if @item.seller == current_user
+  end
+  def confirm_transaction_stage_under_sale
+    redirect_to root_path, alert: "既に販売済みの商品です" unless @item.transaction_stage == "under_sale"
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -73,8 +73,6 @@ class ItemsController < ApplicationController
         :buy_price,
         :commission_price,
         :sell_price,
-        :commition_price,
-        :transaction_stage,
         :like_count,
         :size_id,
         :brand_id,
@@ -82,7 +80,6 @@ class ItemsController < ApplicationController
         :middle_category_id,
         :lower_category_id,
         :seller_id,
-        :buyer_id,
         pictures_attributes: [:id, :content, :status]
       ).merge(transaction_stage: 'under_sale', seller_id: current_user.id)
     end
@@ -97,8 +94,6 @@ class ItemsController < ApplicationController
         :buy_price,
         :commission_price,
         :sell_price,
-        :commition_price,
-        :transaction_stage,
         :like_count,
         :size_id,
         :brand_id,
@@ -106,7 +101,6 @@ class ItemsController < ApplicationController
         :middle_category_id,
         :lower_category_id,
         :seller_id,
-        :buyer_id,
         pictures_attributes: [:id, :content, :status]
       )
     end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,5 +1,6 @@
 class Address < ApplicationRecord
   belongs_to :user
+  has_many :deliverd_items, class_name: 'Item', foreign_key: 'shipping_address_id'
 
   validates :first_name, :last_name, :postal_code, :prefecture, :city, :address, :user_id, presence: true
   validates :first_name_katakana, :last_name_katakana, presence: true, format: { with: /\A[\p{katakana}　ー－&&[^ -~｡-ﾟ]]+\z/, message: 'はカタカナで入力して下さい。'}

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,6 +3,7 @@ class Item < ApplicationRecord
   belongs_to :size, optional: true
   belongs_to :seller, class_name: 'User', foreign_key: 'seller_id', optional: true
   belongs_to :buyer, class_name: 'User', foreign_key: 'buyer_id', optional: true
+  belongs_to :shipping_address, class_name: 'Address', foreign_key: 'shipping_address_id', optional: true
   belongs_to :upper_category, optional: true
   belongs_to :middle_category, optional: true
   belongs_to :lower_category, optional: true

--- a/app/views/buys/edit.html.haml
+++ b/app/views/buys/edit.html.haml
@@ -7,10 +7,10 @@
           = image_tag @image.content, class: 'is-higher-height'
         %p.p-buy_item-name.u-fwBold
           = @item.name
-        = form_with model:@item,scope: :patch,url:item_buy_path, html: {class: 'p-buy_form'} do |f|
+        = form_with model: @item, scope: :patch, url:item_buy_path, html: {class: 'p-buy_form'} do |f|
           %p.p-buy_price-ja.u-fwBold
             ¥
-            = @item.sell_price
+            = @item.buy_price
             %span.p-item_shipping-fee.u-fw14.u-fwBold 送料込み
           %ul.p-buy_accordion
             %li.c-accordion
@@ -35,16 +35,18 @@
                     %label
                       = f.radio_button 'consume_point_radio', 'partial'
                       一部のポイントを使う
-                  = f.number_field :point, placeholder: '使うポイントを入力', class: 'c-input-default'
+                  = f.number_field :discount_point, placeholder: '使うポイントを入力', class: 'c-input-default'
           %ul.p-buy_price-table
             %li.p-buy_price-row.p-buy_you-pay.u-fwBold
               .p-buy_price-cell 支払い金額
               .p-buy_price-cell
                 %span ¥
-                = @item.sell_price
+                = @item.buy_price
+                / @item.buy_price - point
           -# エラーメッセージ,配送先か支払い方法が未登録の際に表示
           -# %p.c-has-error-text
           -#   配送先と支払い方法の入力を完了してください。
+          = f.hidden_field :shipping_address_id, value: 1 #仮置きです
           = f.submit '購入する', class: 'c-btn-default is-red u-fzBold'
     %section.p-buy_content.p-buy_user-info
       .p-buy_content-inner

--- a/db/migrate/20181223052238_create_items.rb
+++ b/db/migrate/20181223052238_create_items.rb
@@ -9,6 +9,7 @@ class CreateItems < ActiveRecord::Migration[5.1]
       t.integer :delivery_duration, null:false, default: 0
       t.integer :buy_price, null:false, default: 0
       t.integer :sell_price, null:false, default: 0
+      t.integer :discount_point, null:false, default: 0
       t.integer :commission_price, null:false, default: 0
       t.integer :transaction_stage, null:false, default: 0
       t.integer :like_count, null:false, default: 0

--- a/db/migrate/20190202094356_add_addresskey_for_items.rb
+++ b/db/migrate/20190202094356_add_addresskey_for_items.rb
@@ -1,0 +1,6 @@
+class AddAddresskeyForItems < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :items, :shipping_address
+    add_foreign_key :items, :addresses, column: :shipping_address_id, index:true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190120135701) do
+ActiveRecord::Schema.define(version: 20190202094356) do
 
   create_table "addresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "first_name", default: "", null: false
@@ -85,6 +85,7 @@ ActiveRecord::Schema.define(version: 20190120135701) do
     t.integer "delivery_duration", default: 0, null: false
     t.integer "buy_price", default: 0, null: false
     t.integer "sell_price", default: 0, null: false
+    t.integer "discount_point", default: 0, null: false
     t.integer "commission_price", default: 0, null: false
     t.integer "transaction_stage", default: 0, null: false
     t.integer "like_count", default: 0, null: false
@@ -97,11 +98,13 @@ ActiveRecord::Schema.define(version: 20190120135701) do
     t.bigint "buyer_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "shipping_address_id"
     t.index ["brand_id"], name: "index_items_on_brand_id"
     t.index ["buyer_id"], name: "index_items_on_buyer_id"
     t.index ["lower_category_id"], name: "index_items_on_lower_category_id"
     t.index ["middle_category_id"], name: "index_items_on_middle_category_id"
     t.index ["seller_id"], name: "index_items_on_seller_id"
+    t.index ["shipping_address_id"], name: "index_items_on_shipping_address_id"
     t.index ["size_id"], name: "index_items_on_size_id"
     t.index ["upper_category_id"], name: "index_items_on_upper_category_id"
   end
@@ -234,6 +237,7 @@ ActiveRecord::Schema.define(version: 20190120135701) do
   add_foreign_key "comments", "items"
   add_foreign_key "comments", "users"
   add_foreign_key "credits", "users"
+  add_foreign_key "items", "addresses", column: "shipping_address_id"
   add_foreign_key "items", "brands"
   add_foreign_key "items", "lower_categories"
   add_foreign_key "items", "middle_categories"


### PR DESCRIPTION
## what
item tableに:shipping_addressと:discount_pointを追加
　itemの購入において、1.配送先住所と2.支払いにおけるポイントの使用料を決めるcolumn
それに伴いassociationを追加
　@address.deliverd_itemsで配送先住所のitemsを
　@item.shipping_addressでitemの配送先住所を呼べるようにした
itemのedit form(購入画面)において、enumの名前をitem出品画面と統一した

## why
itemの購入と出品画面はmercariの重要機能であり、また二つの機能の連携は非常に重要である。