### PR TITLE
update_buy_controllerの修正　他、微調整を含む

### DIFF
--- a/app/controllers/buys_controller.rb
+++ b/app/controllers/buys_controller.rb
@@ -24,7 +24,7 @@ class BuysController < ApplicationController
     @item = Item.find(params[:item_id])
   end
   def buy_params
-    params.require(:patch).permit(:discount_point, :shipping_address_id).merge(buyer_id: current_user.id, transaction_stage: "under_transaction")
+    params.require(:patch).permit(:discount_point).merge(buyer_id: current_user.id, transaction_stage: "under_transaction",shipping_address_id:current_user.addresses.ids[0])
   end
   def confirm_item_seller_and_buyer
     redirect_to root_path, alert: "出品した商品を購入することはできません" if @item.seller == current_user

--- a/app/controllers/credits_controller.rb
+++ b/app/controllers/credits_controller.rb
@@ -16,10 +16,10 @@ include Payjp_process
           redirect_to new_credit_path, alert: "登録できませんでした"
         end
       else
-        redirect_to root_path, alert: "既に登録されています"
+        redirect_to new_credit_path, alert: "既に登録されています"
       end
     else
-      redirect_to new_credit_path, alert: "ログインしてください"
+      redirect_to root_path, alert: "ログインしてください"
     end
   end
 

--- a/app/views/buys/edit.html.haml
+++ b/app/views/buys/edit.html.haml
@@ -43,10 +43,9 @@
                 %span ¥
                 = @item.buy_price
                 / @item.buy_price - point
-          -# エラーメッセージ,配送先か支払い方法が未登録の際に表示
-          -# %p.c-has-error-text
-          -#   配送先と支払い方法の入力を完了してください。
-          = f.hidden_field :shipping_address_id, value: 1 #仮置きです
+          - unless @adress.present?||@credit_data.present?
+            %p.c-has-error-text
+              配送先と支払い方法の入力を完了してください。
           = f.submit '購入する', class: 'c-btn-default is-red u-fzBold'
     %section.p-buy_content.p-buy_user-info
       .p-buy_content-inner

--- a/app/views/credits/new.html.haml
+++ b/app/views/credits/new.html.haml
@@ -59,3 +59,6 @@
                 = image_tag 'signup/seq-card.png', width: '240'
           %p#primary-error.c-has-error-text
           = f.submit '次へ進む', class: 'c-btn-default is-red'
+      %p#primary-error.c-has-error-text
+        /以下は画面操作での便宜上、仮で設置しています
+        = button_to '購入画面へ戻る', edit_item_buy_path(item_id:1),method: :get ,class: 'c-btn-default is-red'


### PR DESCRIPTION
# WHAT

１）buy_controllerの修正を実施
　・Itemテーブルにshipping_address_id（配送先住所id）が追加されたことに伴い、
　　商品購入時点でshipping_address_idに購入者の住所idが登録されるように修正

２）その他の調整
・credit_controllerのredirect先を調整した（仮）
・商品購入画面で、ログイン中ユーザーの「配送先」もしくは「支払方法」が未設定の場合に、
　登録を促すメッセージが表示されるように修正した

# WHY

１）商品購入時点で、購入された商品と商品の配送先を紐付けて登録するため
２）credit_controller開発の初期段階において、便宜上、redirect先を全てroot_pathにしていた
　　現段階でredirectさせる先を改めて設定した（現段階でもあくまで仮設定）
３）配送先、支払情報が無いと購入手続きを完了させられないので、メッセージを画面表示することで
　　ログイン中のユーザーに注意を促す

# NOTE

※クレジット情報の登録画面で、登録完了後に「商品購入ページ」に戻るためのリンクがなく、
　画面操作が手間だったので、仮で商品購入画面へのリンクを設置（後に修正し削除する予定）