### PR TITLE
Develop-create review and transaction_message controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@
 - has_many :user_informations
 
 
-# infomationsテーブル
+# user_infomationsテーブル
 |Column|Type|Options|
 |------|----|-------|
 |user_id|integer|null:false, foreign_key:true|
@@ -212,8 +212,7 @@
   belongs_to :middle_category, optional: true
   belongs_to :lower_category, optional: true
 
-  has_many :sent_reviews, class_name: 'Review', foreign_key: 'appraiser_id'
-  has_many :recieved_reviews, class_name: 'Review', foreign_key: 'appraisee_id'
+  has_many :reviews
   has_many :reports, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :comments, dependent: :destroy

--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@
   belongs_to :middle_category, optional: true
   belongs_to :lower_category, optional: true
 
-  has_many :reviews, dependent: :destroy
+  has_many :sent_reviews, class_name: 'Review', foreign_key: 'appraiser_id'
+  has_many :recieved_reviews, class_name: 'Review', foreign_key: 'appraisee_id'
   has_many :reports, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :comments, dependent: :destroy

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,4 +45,11 @@ class ApplicationController < ActionController::Base
   def set_locale
     I18n.locale = :ja
   end
+
+  def confirm_transaction_stage_under_transaction
+    redirect_to mypages_path unless @item.transaction_stage == 'under_transaction'
+  end
+  def confirm_buyer_or_seller_include_current_user
+    redirect_to mypages_path unless [@item.buyer_id, @item.seller_id].include?(current_user.id)
+  end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,6 +1,8 @@
 class ReviewsController < ApplicationController
+  before_action :move_to_sign_in
   before_action :set_item, only: [:new, :edit, :create, :update]
   before_action :set_review, only: [:show, :edit, :update, :destroy]
+  before_action :confirm_buyer_or_seller_include_current_user, except: [:index, :show]
   before_action :confirm_transaction_stage_under_transaction, except: [:index, :show]
   before_action :confirm_item_appraiser_existence_and_item_buyer_already_create_review, only: [:new, :create]
   after_action :update_transaction_stage_to_sold_out, only: :create
@@ -53,9 +55,6 @@ class ReviewsController < ApplicationController
         @appraisee_id = @item.seller_id
       end
       params.require(:review).permit(:text, :evaluation, :item_id).merge(appraiser_id: current_user.id, appraisee_id: @appraisee_id, item_id: params[:item_id])
-    end
-    def confirm_transaction_stage_under_transaction
-      redirect_to mypages_path unless @item.transaction_stage == 'under_transaction'
     end
     def confirm_item_appraiser_existence_and_item_buyer_already_create_review
       @item_appraiser_ids = ['dammy']

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -22,6 +22,7 @@ class ReviewsController < ApplicationController
 
   def create
     if @review = Review.create(review_params)
+      update_user_review_count
       redirect_to mypages_path, notice: 'Review was successfully created.'
     else
       render :new
@@ -72,5 +73,19 @@ class ReviewsController < ApplicationController
       elsif @item.reviews.length == 1
         @item.update(transaction_stage: 'sold_out')
       end
+    end
+    def update_user_review_count
+      @appraisee = @review.appraisee
+      @good_count = @appraisee.good_count
+      @normal_count = @appraisee.normal_count
+      @bad_count = @appraisee.bad_count
+      if @review.evaluation == 'good'
+        @good_count += 1
+      elsif @review.evaluation == 'normal'
+        @normal_count += 1
+      else
+        @bad_count += 1
+      end
+      @appraisee.update(good_count: @good_count, normal_count: @normal_count, bad_count: @bad_count)
     end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,74 +1,53 @@
 class ReviewsController < ApplicationController
+  before_action :set_item, only: [:new, :edit, :create, :update]
   before_action :set_review, only: [:show, :edit, :update, :destroy]
 
-  # GET /reviews
-  # GET /reviews.json
   def index
-    @reviews = Review.all
+    @recieved_reviews = current_user.received_reviews
+    @sent_reviews = current_user.sent_reviews
   end
 
-  # GET /reviews/1
-  # GET /reviews/1.json
   def show
   end
 
-  # GET /reviews/new
   def new
     @review = Review.new
   end
 
-  # GET /reviews/1/edit
   def edit
   end
 
-  # POST /reviews
-  # POST /reviews.json
   def create
-    @review = Review.new(review_params)
-
-    respond_to do |format|
-      if @review.save
-        format.html { redirect_to @review, notice: 'Review was successfully created.' }
-        format.json { render :show, status: :created, location: @review }
-      else
-        format.html { render :new }
-        format.json { render json: @review.errors, status: :unprocessable_entity }
-      end
+    if @review = Review.create(review_params)
+      redirect_to @review, notice: 'Review was successfully created.'
+    else
+      render :new
     end
   end
 
-  # PATCH/PUT /reviews/1
-  # PATCH/PUT /reviews/1.json
   def update
-    respond_to do |format|
-      if @review.update(review_params)
-        format.html { redirect_to @review, notice: 'Review was successfully updated.' }
-        format.json { render :show, status: :ok, location: @review }
-      else
-        format.html { render :edit }
-        format.json { render json: @review.errors, status: :unprocessable_entity }
-      end
-    end
-  end
-
-  # DELETE /reviews/1
-  # DELETE /reviews/1.json
-  def destroy
-    @review.destroy
-    respond_to do |format|
-      format.html { redirect_to reviews_url, notice: 'Review was successfully destroyed.' }
-      format.json { head :no_content }
+    if @review = Review.update(review_params)
+      redirect_to @review, notice: 'Review was successfully created.'
+    else
+      render :edit
     end
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
+
     def set_review
       @review = Review.find(params[:id])
     end
+    def set_item
+      @item = Item.find(params[:item_id])
+    end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
     def review_params
-      params.fetch(:review, {})
+      if current_user == @item.seller
+        @appraisee_id = @item.buyer_id
+      else
+        @appraisee_id = @item.seller_id
+      end
+      params.require(:review).permit(:text, :evaluation, :item_id).merge(appraiser_id: current_user.id, appraisee_id: @appraisee_id, item_id: params[:item_id])
     end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,6 +1,9 @@
 class ReviewsController < ApplicationController
   before_action :set_item, only: [:new, :edit, :create, :update]
   before_action :set_review, only: [:show, :edit, :update, :destroy]
+  before_action :confirm_transaction_stage_under_transaction, except: [:index, :show]
+  before_action :confirm_item_appraiser_existence_and_item_buyer_already_create_review, only: [:new, :create]
+  after_action :update_transaction_stage_to_sold_out, only: :create
 
   def index
     @recieved_reviews = current_user.received_reviews
@@ -19,7 +22,7 @@ class ReviewsController < ApplicationController
 
   def create
     if @review = Review.create(review_params)
-      redirect_to @review, notice: 'Review was successfully created.'
+      redirect_to mypages_path, notice: 'Review was successfully created.'
     else
       render :new
     end
@@ -27,7 +30,7 @@ class ReviewsController < ApplicationController
 
   def update
     if @review = Review.update(review_params)
-      redirect_to @review, notice: 'Review was successfully created.'
+      redirect_to mypages_path, notice: 'Review was successfully created.'
     else
       render :edit
     end
@@ -49,5 +52,25 @@ class ReviewsController < ApplicationController
         @appraisee_id = @item.seller_id
       end
       params.require(:review).permit(:text, :evaluation, :item_id).merge(appraiser_id: current_user.id, appraisee_id: @appraisee_id, item_id: params[:item_id])
+    end
+    def confirm_transaction_stage_under_transaction
+      redirect_to mypages_path unless @item.transaction_stage == 'under_transaction'
+    end
+    def confirm_item_appraiser_existence_and_item_buyer_already_create_review
+      @item_appraiser_ids = ['dammy']
+      @item.reviews.each do |review|
+        @item_appraiser_ids << review.appraiser_id
+      end
+      redirect_to mypages_path if @item_appraiser_ids.include?(current_user.id)
+      if current_user == @item.seller
+        redirect_to mypages_path unless @item_appraiser_ids.include?(@item.buyer_id)
+      end
+    end
+    def update_transaction_stage_to_sold_out
+      if @item.reviews.length == 0
+        #create todo
+      elsif @item.reviews.length == 1
+        @item.update(transaction_stage: 'sold_out')
+      end
     end
 end

--- a/app/controllers/transaction_messages_controller.rb
+++ b/app/controllers/transaction_messages_controller.rb
@@ -1,5 +1,7 @@
 class TransactionMessagesController < ApplicationController
+  before_action :move_to_sign_in
   before_action :set_item_and_transaction_messages
+  before_action :confirm_buyer_or_seller_include_current_user
   before_action :confirm_transaction_stage_under_transaction
 
   def index
@@ -18,8 +20,5 @@ class TransactionMessagesController < ApplicationController
     @transaction_message = TransactionMessage.new
     @item = Item.find(params[:item_id])
     @transaction_messages = @item.transaction_messages
-  end
-  def confirm_transaction_stage_under_transaction
-    redirect_to mypages_path unless @item.transaction_stage == 'under_transaction'
   end
 end

--- a/app/controllers/transaction_messages_controller.rb
+++ b/app/controllers/transaction_messages_controller.rb
@@ -8,7 +8,7 @@ class TransactionMessagesController < ApplicationController
   end
 
   def create
-    TransactionMessage.create(transaction_message_params)
+    @created_transaction_message = TransactionMessage.create(transaction_message_params)
   end
 
   private

--- a/app/controllers/transaction_messages_controller.rb
+++ b/app/controllers/transaction_messages_controller.rb
@@ -1,74 +1,25 @@
 class TransactionMessagesController < ApplicationController
-  before_action :set_transaction_message, only: [:show, :edit, :update, :destroy]
+  before_action :set_item_and_transaction_messages
+  before_action :confirm_transaction_stage_under_transaction
 
-  # GET /transaction_messages
-  # GET /transaction_messages.json
   def index
-    @transaction_messages = TransactionMessage.all
   end
 
-  # GET /transaction_messages/1
-  # GET /transaction_messages/1.json
-  def show
-  end
-
-  # GET /transaction_messages/new
-  def new
-    @transaction_message = TransactionMessage.new
-  end
-
-  # GET /transaction_messages/1/edit
-  def edit
-  end
-
-  # POST /transaction_messages
-  # POST /transaction_messages.json
   def create
-    @transaction_message = TransactionMessage.new(transaction_message_params)
-
-    respond_to do |format|
-      if @transaction_message.save
-        format.html { redirect_to @transaction_message, notice: 'Transaction message was successfully created.' }
-        format.json { render :show, status: :created, location: @transaction_message }
-      else
-        format.html { render :new }
-        format.json { render json: @transaction_message.errors, status: :unprocessable_entity }
-      end
-    end
-  end
-
-  # PATCH/PUT /transaction_messages/1
-  # PATCH/PUT /transaction_messages/1.json
-  def update
-    respond_to do |format|
-      if @transaction_message.update(transaction_message_params)
-        format.html { redirect_to @transaction_message, notice: 'Transaction message was successfully updated.' }
-        format.json { render :show, status: :ok, location: @transaction_message }
-      else
-        format.html { render :edit }
-        format.json { render json: @transaction_message.errors, status: :unprocessable_entity }
-      end
-    end
-  end
-
-  # DELETE /transaction_messages/1
-  # DELETE /transaction_messages/1.json
-  def destroy
-    @transaction_message.destroy
-    respond_to do |format|
-      format.html { redirect_to transaction_messages_url, notice: 'Transaction message was successfully destroyed.' }
-      format.json { head :no_content }
-    end
+    TransactionMessage.create(transaction_message_params)
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_transaction_message
-      @transaction_message = TransactionMessage.find(params[:id])
-    end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def transaction_message_params
-      params.fetch(:transaction_message, {})
-    end
+  def transaction_message_params
+    params.require(:transaction_message).permit(:text).merge(user_id: current_user.id, item_id: params[:item_id])
+  end
+  def set_item_and_transaction_messages
+    @transaction_message = TransactionMessage.new
+    @item = Item.find(params[:item_id])
+    @transaction_messages = @item.transaction_messages
+  end
+  def confirm_transaction_stage_under_transaction
+    redirect_to mypages_path unless @item.transaction_stage == 'under_transaction'
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,7 +8,8 @@ class Item < ApplicationRecord
   belongs_to :middle_category, optional: true
   belongs_to :lower_category, optional: true
 
-  has_many :reviews, dependent: :destroy
+  has_many :sent_reviews, class_name: 'Review', foreign_key: 'appraiser_id'
+  has_many :recieved_reviews, class_name: 'Review', foreign_key: 'appraisee_id'
   has_many :reports, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :comments, dependent: :destroy

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,8 +8,7 @@ class Item < ApplicationRecord
   belongs_to :middle_category, optional: true
   belongs_to :lower_category, optional: true
 
-  has_many :sent_reviews, class_name: 'Review', foreign_key: 'appraiser_id'
-  has_many :recieved_reviews, class_name: 'Review', foreign_key: 'appraisee_id'
+  has_many :reviews, dependent: :destroy
   has_many :reports, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :comments, dependent: :destroy

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -5,5 +5,9 @@ class Review < ApplicationRecord
 
   validates :text, :evaluation, :item_id, :appraisee_id, :appraiser_id, presence: true
 
-  enum evaluation: { "-----": 0, good: 1, normal: 2, bad: 3 }
+  enum evaluation: {
+    good: 1,
+    normal: 2,
+    bad: 3
+  }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ApplicationRecord
   has_many :transaction_messages, dependent: :destroy
   has_many :addresses, dependent: :destroy
   has_many :avatars, dependent: :destroy, inverse_of: :user
-  has_many :credits,dependent: :destroy
+  has_many :credits, dependent: :destroy
   has_one :phone_number, dependent: :destroy
   accepts_nested_attributes_for :avatars, allow_destroy: true
 

--- a/app/views/layouts/_side_mypage.html.haml
+++ b/app/views/layouts/_side_mypage.html.haml
@@ -16,7 +16,7 @@
           やることリスト
           %i.c-icon-arrow-right
       %li
-        = link_to mypage_likes_path(current_user.id), class: 'p-mypage_nav_list-item' do
+        = link_to likes_path, class: 'p-mypage_nav_list-item' do
           いいね！一覧
           %i.c-icon-arrow-right
       %li
@@ -48,7 +48,7 @@
           ニュース一覧
           %i.c-icon-arrow-right
       %li
-        = link_to mypage_reviews_path(current_user.id), class: 'p-mypage_nav_list-item' do
+        = link_to reviews_path, class: 'p-mypage_nav_list-item' do
           評価一覧
           %i.c-icon-arrow-right
       %li

--- a/app/views/mypages/index.html.haml
+++ b/app/views/mypages/index.html.haml
@@ -50,4 +50,4 @@
       %h2.c-items-box_head
         この出品者の商品
       .c-items-box_content.l-clearfix
-        =render :partial => "layouts/itembox", :collection => @items, :as => "item"
+        = render :partial => "layouts/itembox", :collection => @items, :as => "item"

--- a/app/views/reviews/_form.html.haml
+++ b/app/views/reviews/_form.html.haml
@@ -8,14 +8,17 @@
   .c-radio-default
     %label
       = f.radio_button :evaluation, 'good'
+      good
       %br
   .c-radio-default
     %label
       = f.radio_button :evaluation, 'normal'
+      normal
       %br
   .c-radio-default
     %label
       = f.radio_button :evaluation, 'bad'
+      bad
       %br
   = f.text_field :text
 

--- a/app/views/reviews/_form.html.haml
+++ b/app/views/reviews/_form.html.haml
@@ -1,10 +1,23 @@
-= form_for @review do |f|
+= form_with model: [item, review], local: true do |f|
   - if @review.errors.any?
     #error_explanation
       %h2= "#{pluralize(@review.errors.count, "error")} prohibited this review from being saved:"
       %ul
         - @review.errors.full_messages.each do |message|
           %li= message
+  .c-radio-default
+    %label
+      = f.radio_button :evaluation, 'good'
+      %br
+  .c-radio-default
+    %label
+      = f.radio_button :evaluation, 'normal'
+      %br
+  .c-radio-default
+    %label
+      = f.radio_button :evaluation, 'bad'
+      %br
+  = f.text_field :text
 
   .actions
-    = f.submit 'Save'
+    = f.submit 'Save', class: 'c-btn-default is-red u-fzBold'

--- a/app/views/reviews/_review.json.jbuilder
+++ b/app/views/reviews/_review.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! review, :id, :created_at, :updated_at
-json.url review_url(review, format: :json)

--- a/app/views/reviews/edit.html.haml
+++ b/app/views/reviews/edit.html.haml
@@ -1,7 +1,3 @@
 %h1 Editing review
 
 = render 'form'
-
-= link_to 'Show', @review
-\|
-= link_to 'Back', reviews_path

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -8,12 +8,13 @@
       %th
 
   %tbody
-    - @reviews.each do |review|
+    - if @sent_reviews != nil
+      - @sent_reviews.each do |sent_review|
+        = sent_review.text
+    - if @received_reviews != nil
+      - @received_reviews.each do |received_review|
+        = received_review.text
       %tr
         %td= link_to 'Show', review
         %td= link_to 'Edit', edit_review_path(review)
         %td= link_to 'Destroy', review, method: :delete, data: { confirm: 'Are you sure?' }
-
-%br
-
-= link_to 'New Review', new_review_path

--- a/app/views/reviews/index.json.jbuilder
+++ b/app/views/reviews/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @reviews, partial: 'reviews/review', as: :review

--- a/app/views/reviews/new.html.haml
+++ b/app/views/reviews/new.html.haml
@@ -1,5 +1,4 @@
 %h1 New review
 
-= render 'form'
+= render 'form', item: @item, review: @review
 
-= link_to 'Back', reviews_path

--- a/app/views/reviews/show.json.jbuilder
+++ b/app/views/reviews/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! "reviews/review", review: @review

--- a/app/views/transaction_messages/_form.html.haml
+++ b/app/views/transaction_messages/_form.html.haml
@@ -1,10 +1,12 @@
-= form_for @transaction_message do |f|
+= form_with model: [@item, @transaction_message], authenticity_token: true do |f|
   - if @transaction_message.errors.any?
     #error_explanation
-      %h2= "#{pluralize(@transaction_message.errors.count, "error")} prohibited this transaction_message from being saved:"
+      %h2= "#{pluralize(@transaction_message.errors.count, "error")} prohibited this review from being saved:"
       %ul
         - @transaction_message.errors.full_messages.each do |message|
           %li= message
 
+  = f.text_field :text
+
   .actions
-    = f.submit 'Save'
+    = f.submit 'Save', class: 'c-btn-default is-red u-fzBold'

--- a/app/views/transaction_messages/_form.html.haml
+++ b/app/views/transaction_messages/_form.html.haml
@@ -1,9 +1,9 @@
 = form_with model: [@item, @transaction_message], authenticity_token: true do |f|
-  - if @transaction_message.errors.any?
+  - if @created_transaction_message.errors.any?
     #error_explanation
-      %h2= "#{pluralize(@transaction_message.errors.count, "error")} prohibited this review from being saved:"
+      %h2= "#{pluralize(@created_transaction_message.errors.count, "error")} prohibited this review from being saved:"
       %ul
-        - @transaction_message.errors.full_messages.each do |message|
+        - @created_transaction_message.errors.full_messages.each do |message|
           %li= message
 
   = f.text_field :text

--- a/app/views/transaction_messages/_transaction_message.html.haml
+++ b/app/views/transaction_messages/_transaction_message.html.haml
@@ -1,0 +1,4 @@
+- if transaction_message.user_id == current_user.id
+  = transaction_message.text #左サイド
+- else
+  = transaction_message.text #右サイド

--- a/app/views/transaction_messages/_transaction_message.json.jbuilder
+++ b/app/views/transaction_messages/_transaction_message.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! transaction_message, :id, :created_at, :updated_at
-json.url transaction_message_url(transaction_message, format: :json)

--- a/app/views/transaction_messages/create.js.erb
+++ b/app/views/transaction_messages/create.js.erb
@@ -1,0 +1,6 @@
+$('#transaction_messages').html(
+  "<%= j(render :partial => "transaction_message", :collection => @transaction_messages, :as => "transaction_message") %>"
+);
+$('#transaction_messages_form').html(
+  "<%= j(render 'form', locals: {item: @item, transaction_message: @transaction_message}) %>"
+);

--- a/app/views/transaction_messages/edit.html.haml
+++ b/app/views/transaction_messages/edit.html.haml
@@ -1,7 +1,0 @@
-%h1 Editing transaction_message
-
-= render 'form'
-
-= link_to 'Show', @transaction_message
-\|
-= link_to 'Back', transaction_messages_path

--- a/app/views/transaction_messages/index.html.haml
+++ b/app/views/transaction_messages/index.html.haml
@@ -1,19 +1,12 @@
-%h1 Listing transaction_messages
+#transaction_messages
+  = render :partial => "transaction_message", :collection => @transaction_messages, :as => "transaction_message"
 
-%table
-  %thead
-    %tr
-      %th
-      %th
-      %th
+#transaction_messages_form
+  = render 'form', locals: {item: @item, transaction_message: @transaction_message}
 
-  %tbody
-    - @transaction_messages.each do |transaction_message|
-      %tr
-        %td= link_to 'Show', transaction_message
-        %td= link_to 'Edit', edit_transaction_message_path(transaction_message)
-        %td= link_to 'Destroy', transaction_message, method: :delete, data: { confirm: 'Are you sure?' }
 
-%br
-
-= link_to 'New Transaction message', new_transaction_message_path
+= link_to new_item_review_path(@item) do
+  - if current_user.id == @item.buyer_id
+    受け取り評価する(buyer)
+  - else
+    評価する(seller)

--- a/app/views/transaction_messages/index.json.jbuilder
+++ b/app/views/transaction_messages/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @transaction_messages, partial: 'transaction_messages/transaction_message', as: :transaction_message

--- a/app/views/transaction_messages/new.html.haml
+++ b/app/views/transaction_messages/new.html.haml
@@ -1,5 +1,0 @@
-%h1 New transaction_message
-
-= render 'form'
-
-= link_to 'Back', transaction_messages_path

--- a/app/views/transaction_messages/show.html.haml
+++ b/app/views/transaction_messages/show.html.haml
@@ -1,6 +1,0 @@
-%p#notice= notice
-
-
-= link_to 'Edit', edit_transaction_message_path(@transaction_message)
-\|
-= link_to 'Back', transaction_messages_path

--- a/app/views/transaction_messages/show.json.jbuilder
+++ b/app/views/transaction_messages/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! "transaction_messages/transaction_message", transaction_message: @transaction_message

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,3 +19,8 @@ ja:
         under_sale: '出品中'
         under_transaction: '取引中'
         sold_out: '売却済'
+    review:
+      evaluation:
+        good: '良い'
+        normal: '普通'
+        bad: '悪い'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
     resources :reports, only: [:create, :destroy]
     resources :likes, only: [:create, :destroy]
     resources :comments, only: [:create, :update, :destroy]
-    resources :transaction_messages
+    resources :transaction_messages, only: [:index, :create]
     resource :buy, only: [:edit,:update]
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   match 'dynamic_middle_category', to: 'items#dynamic_middle_category', via: [:get, :post]
   match 'dynamic_lower_category', to: 'items#dynamic_lower_category', via: [:get, :post]
   resources :items do
-    resources :reviews
+    resources :reviews, only: [:new, :create, :edit, :update]
     resources :reports, only: [:create, :destroy]
     resources :likes, only: [:create, :destroy]
     resources :comments, only: [:create, :update, :destroy]
@@ -31,10 +31,9 @@ Rails.application.routes.draw do
   resources :lower_categories, only: [:show]
 
   get 'logout' => 'mypages#logout'
-  resources :mypages, only: [:index, :show, :edit, :update] do
-    resources :likes, only: [:index]
-    resources :reviews, only: [:index]
-  end
+  resources :mypages, only: [:index, :show, :edit, :update]
+  resources :likes, only: [:index]
+  resources :reviews, only: [:index, :show]
   resources :addresses, only: [:index, :new, :create, :edit, :update]
   resources :phone_numbers, only: [:new, :create, :edit, :update]
   resources :credits, only: [:new, :create, :delete, :index]


### PR DESCRIPTION
## what
itemが購入された後の、取引者同士によるmessageのやり取りを管理するtransaction_messages controllerと、その後のお互いの評価を行うreview controllerを作成した。(サーバーサイドのみ)

・itemが購入される(itemのもつtransaction_stageがunder_sale: 1からunder_transaction:2に変化する)とtransaction_messagesとreviewが使えるようになる。
・itemのbuyerかsellerのみreviewとtransaction_messageを使用できる。
・userは同じitemに対して、2回以上reviewを作成できない
・出品者(seller)は購入者(buyer)がreviewするまでreviewできない(購入者のreview作成は商品の受け取りを意味するため)
・出品者と購入者の両方がreviewを作成することで、transaction_stageがunder_transaction: 2からsold_out: 3に変化する(同時にreviewとtransaction_messageは使えなくなる)
・reviewが作成されるたび、評価に応じてuserのgood, normal, bad_countが増加する

## future
・transaction_stageの変化に合わせたお金の移動、お知らせ作成、Todo作成
・発送完了ボタンとそのお知らせ機能
・view作成

## why
reviewとtransaction_messageはitemの購入後から最終的な取引の終了(mercariからのお金の支払い)までを繋ぐ重要な機能である。
今回のpull requestでは、上記のような取引の流れとどのような制約を入れるかを意識した。
