### PR TITLE
出品商品詳細ページの実装

### DIFF
--- a/app/controllers/buys_controller.rb
+++ b/app/controllers/buys_controller.rb
@@ -2,6 +2,7 @@ class BuysController < ApplicationController
   before_action :set_item
   before_action :confirm_item_seller_and_buyer
   before_action :confirm_transaction_stage_under_sale
+  before_action :confirm_user_sign_in
 
   include Payjp_process
 
@@ -32,4 +33,8 @@ class BuysController < ApplicationController
   def confirm_transaction_stage_under_sale
     redirect_to root_path, alert: "既に販売済みの商品です" unless @item.transaction_stage == "under_sale"
   end
+  def confirm_user_sign_in
+    redirect_to root_path, alert: "ログインして下さい" unless user_signed_in?
+  end
+
 end

--- a/app/controllers/descriptions_controller.rb
+++ b/app/controllers/descriptions_controller.rb
@@ -1,0 +1,4 @@
+class DescriptionsController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,6 +20,7 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.includes(:transaction_messages).find(params[:id])
     @seller = User.find(@item.seller_id)
     @other_items = Item.where(seller_id: @item.seller_id)
     @brand = Brand.find(@item.brand_id)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,6 +20,13 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @seller = User.find(@item.seller_id)
+    @other_items = Item.where(seller_id: @item.seller_id)
+    @brand = Brand.find(@item.brand_id)
+    @upper_category = UpperCategory.find(@item.upper_category_id)
+    @middle_category = MiddleCategory.find(@item.middle_category_id)
+    @lower_category = LowerCategory.find(@item.lower_category_id)
+    @sizes = Size.find(@item.size_id)
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,6 +28,7 @@ class ItemsController < ApplicationController
     @middle_category = MiddleCategory.find(@item.middle_category_id)
     @lower_category = LowerCategory.find(@item.lower_category_id)
     @sizes = Size.find(@item.size_id)
+    random_page_link
   end
 
   def new
@@ -118,4 +119,15 @@ class ItemsController < ApplicationController
     def middle_category_params
       params.require(:item).permit(:middle_category_id)
     end
+
+  def random_page_link
+    #ランダムなページリンクを生成する
+    rand_ranges = Item.all.count
+    random = Random.new
+    @rand_next = random.rand(rand_ranges)+1
+    @next_page = Item.find(@rand_next)
+    @rand_prev = random.rand(rand_ranges)+1
+    @prev_page = Item.find(@rand_prev)
+  end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,6 +23,7 @@ class ItemsController < ApplicationController
     @item = Item.includes(:transaction_messages).find(params[:id])
     @seller = User.find(@item.seller_id)
     @other_items = Item.where(seller_id: @item.seller_id)
+    @other_brand_items = Item.where(brand_id: @item.brand_id)
     @brand = Brand.find(@item.brand_id)
     @upper_category = UpperCategory.find(@item.upper_category_id)
     @middle_category = MiddleCategory.find(@item.middle_category_id)

--- a/app/views/descriptions/show.html.haml
+++ b/app/views/descriptions/show.html.haml
@@ -1,0 +1,68 @@
+.l-default-container
+  %section.p-item_box-container.l-single_container
+    %h1.p-item_name
+      みなさまに安心してお取引を楽しんでいただくために、メルカリが取り組んでいることをご紹介します。
+.l-default-container
+  %section.p-item_box-container.l-single_container
+    %h1.p-item_name
+      １．安心できるお金のやりとり
+.l-default-container
+  %section.p-item_box-container.l-single_container
+    %h1.p-item_name
+      商品代金を一時的にメルカリがお預かりする独自の売買システムにより、「商品を発送したのに代金が支払われない」「支払ったのに商品が届かない」等、お金に関するトラブルを防止しています。
+.l-default-container
+  %section.p-item_box-container.l-single_container
+    %h1.p-item_name
+      ２．安心配送システム「メルカリ便」
+.l-default-container
+  %section.p-item_box-container.l-single_container
+    %h1.p-item_name
+      配送方法で「らくらくメルカリ便」、「ゆうゆうメルカリ便」をお選びいただくと、出品者と購入者が互いに名前や住所を知らせることなく取引ができます。また、配送時のトラブルにより商品紛失・破損等が発生した際には、メルカリが商品代金/販売利益を全額補償いたします。
+.l-default-container
+  %section.p-item_box-container.l-single_container
+    %h1.p-item_name
+      ３．充実したサポート・補償体制
+.l-default-container
+  %section.p-item_box-container.l-single_container
+    %h1.p-item_name
+      「商品が届かない」「商品に不備があった」「購入者が受取評価をしてくれない」等のトラブルにあわれた場合、カスタマーサービスが解決に向けてサポートし、状況に応じて補償を行います。お困りの際には、メルカリ事務局にお気軽にお問い合わせください。
+.l-default-container
+  %section.p-item_box-container.l-single_container
+    %h1.p-item_name
+      ４．安全のパトロール体制
+.l-default-container
+  %section.p-item_box-container.l-single_container
+    %h1.p-item_name
+      専門スタッフが365日24時間体制で迷惑行為や不正出品物のチェックを行っており、トラブルの未然防止を推進しています。また、AIや機械学習等のテクノロジーを応用することで、モニタリングの精度を向上させています。
+.l-default-container
+  %section.p-item_box-container.l-single_container
+    %h1.p-item_name
+      ５．偽ブランド品の撲滅
+.l-default-container
+  %section.p-item_box-container.l-single_container
+    %h1.p-item_name
+      メルカリは、ブランド権利者と協力のうえ、模倣品（偽ブランド品）の取り締まりを強化しています。万が一、偽物の疑いのある商品が届いた場合は、お問い合わせをお願いします。事実確認のうえ、当社の基準に則り、最大で全額（商品購入相当額等）を補償いたします。
+.l-default-container
+  %section.p-item_box-container.l-single_container
+    %h1.p-item_name
+      ６．捜査機関や官公庁との連携
+.l-default-container
+  %section.p-item_box-container.l-single_container
+    %h1.p-item_name
+      メルカリでのトラブルや犯罪を未然に防ぐために、警察や国民生活センター・消費生活センターとの情報交換や勉強会等を積極的に行っています。
+.l-default-container
+  %section.p-item_box-container.l-single_container
+    %h1.p-item_name
+      気をつけていても、トラブルに巻き込まれてしまった場合は
+.l-default-container
+  %section.p-item_box-container.l-single_container
+    %h1.p-item_name
+      ①アプリ内のサイドメニュー、もしくはWeb内のマイページから、すぐにメルカリ事務局にお問い合わせください
+.l-default-container
+  %section.p-item_box-container.l-single_container
+    %h1.p-item_name
+      ②メルカリ事務局からの連絡をお待ちください
+.l-default-container
+  %section.p-item_box-container.l-single_container
+    %h1.p-item_name
+      ※未成年の方はまずは保護者にご相談のうえ、お問い合わせください

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -6,7 +6,7 @@
       .p-item_photo
         .owl-carousel.owl-loaded.owl-drag.js-owl-carousel-item
           %div.p-item_photo_item
-            = image_tag @item.pictures.first.content
+            = image_tag @item.pictures[0].content
       %table.p-item_detail-table
         %tbody
           %tr
@@ -43,7 +43,7 @@
           %tr
             %th ブランド
             %td
-              = link_to '/brand/3117/' do
+              = link_to '#' do
                 = @brand.name
           %tr
             %th 商品の状態
@@ -55,11 +55,11 @@
               = @item.delivery_payer_i18n
           %tr
             %th 配送の方法
-            %td カラム確認(普通郵便(定形、定形外))
+            %td 要確認(普通郵便(定形、定形外))
           %tr
             %th 配送元地域
             %td
-              = link_to '/brand/3117/' do
+              = link_to items_path do
                 = @item.delivery_region
           %tr
             %th 発送日の目安

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -127,26 +127,26 @@
             %span コメントする
     %ul.p-item_nav-link.l-clearfix
       %li.p-item_nav-link_prev
-        = link_to '/' do
+        = link_to "#{@rand_prev}" do
           %i.c-icon-arrow-left>
-          マグ＆スプーンセット  きのこ
+          = @next_page.name
       %li.p-item_nav-link_next
-        = link_to '/' do
-          ★ちくわさん専用★エフデ ♡リボン スエード レザーグローブ♡手袋
+        = link_to '#{@rand_next}' do
           %i.c-icon-arrow-right
+          = @next_page.name
     .c-item_social-media-box
       %ul.c-social-media-box
         %li
-          = link_to '#', target: '_blank', class: 'c-share-btn' do
+          = link_to user_facebook_omniauth_authorize_path, target: '_blank', class: 'c-share-btn' do
             %i.c-icon-facebook
         %li
-          = link_to '#', target: '_blank', class: 'c-share-btn' do
+          = link_to user_twitter_omniauth_authorize_path, target: '_blank', class: 'c-share-btn' do
             %i.c-icon-twitter
         %li.social-hidden-item
           = link_to '#', target: '_blank', class: 'c-share-btn' do
             %i.c-icon-line
         %li
-          = link_to '#', target: '_blank', class: 'c-share-btn' do
+          = link_to user_instagram_omniauth_authorize_path, target: '_blank', class: 'c-share-btn' do
             %i.c-icon-pinterest
     .c-items-in-user-profile
       %section.c-items-box_container.l-clearfix.c-items-box_overflow.c-items-in-user-profile

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,6 +1,183 @@
-%p#notice= notice
-
-
-= link_to 'Edit', edit_item_path(@item)
-\|
-= link_to 'Back', items_path
+.l-default-container
+  %section.p-item_box-container.l-single_container
+    %h1.p-item_name
+      = @item.name
+    .p-item_main-content.l-clearfix
+      .p-item_photo
+        .owl-carousel.owl-loaded.owl-drag.js-owl-carousel-item
+          %div.p-item_photo_item
+            = image_tag @item.pictures.first.content
+      %table.p-item_detail-table
+        %tbody
+          %tr
+            %th 出品者
+            %td
+              = link_to @seller.nickname
+              %div
+                .p-item_user-ratings
+                  %i.c-icon-good
+                  %span
+                    = @seller.good_count
+                .p-item_user-ratings
+                  %i.c-icon-normal
+                  %span
+                    = @seller.normal_count
+                .p-item_user-ratings
+                  %i.c-icon-bad
+                  %span
+                    = @seller.bad_count
+          %tr
+            %th カテゴリー
+            %td
+              = link_to '#' do
+                = @upper_category.name
+              = link_to '#' do
+                .p-item_detail-table-sub-category
+                  %i.c-icon-arrow-right
+                  = @middle_category.name
+              = link_to '#' do
+                .p-item_detail-table-sub-sub-category
+                  %i.c-icon-arrow-right
+                  = @lower_category.name
+          %tr
+            %th ブランド
+            %td
+              = link_to '/brand/3117/' do
+                %div
+                  = @brand.name
+          %tr
+            %th 商品の状態
+            %td
+              = @item.state_i18n
+          %tr
+            %th 配送料の負担
+            %td
+              = @item.delivery_payer_i18n
+          %tr
+            %th 配送の方法
+            %td カラム確認(普通郵便(定形、定形外))
+          %tr
+            %th 配送元地域
+            %td
+              = link_to @item.delivery_region
+          %tr
+            %th 発送日の目安
+            %td
+              =@item.delivery_duration_i18n
+    .p-item_price-box.u-taCenter
+      %span.p-item_price.u-fwBold ¥
+      = @item.buy_price
+      %span.p-item_tax (税込)
+      %span.p-item_shipping-fee
+      = @item.delivery_payer_i18n
+    .u-taCenter
+      .p-item_sales-point-message
+        P 500 をお持ちです
+    = link_to '購入画面に進む',edit_item_buy_path(@item), class: 'p-item_buy-btn u-fz18-24'
+    .p-item_description.u-fz14
+      %p.p-item_description-inner
+        = @item.description
+    .p-item_button-container.l-clearfix
+      .c-item-button-left
+        = button_tag class: 'c-item-button c-item-button-like' do
+          %i.c-icon-like-border
+          %span いいね!
+          %span.is-fade-in-down
+            = @item.like_count
+        = link_to '#report-item', class: 'c-item-button c-item-button-report l-clearfix js-modal' do
+          %i.c-icon-flag
+          %span 不適切な商品の報告
+      .c-item-button-right
+        = link_to '/safe/description/', target:'_blank' do
+          %i.c-icon-lock
+          %span あんしん・あんぜんへの取り組み
+  .p-item_message
+    .p-item_message_container
+      .p-item_message_content
+        %ul.p-item_message_block
+          %li.l-clearfix
+            = link_to '#', class: 'p-item_message_user' do
+              %figure
+                %div
+                  = image_tag 'common/member_photo_noimage_thumb.png'
+                %figcaption.u-fwBold
+                  はる
+            .p-item_message_body
+              .p-item_message_body-text 購入希望です^_^
+              .p-item_message_icons.l-clearfix
+                %time.p-item_message_icon-left
+                  %i.c-icon-time
+                  %span 4 日前
+                .p-item_message_icon-right
+                  = form_for '#', html: {class: 'c-message-form'} do |f|
+                    = button_tag '' do
+                      %i.c-icon-flag
+              %i.c-icon-balloon
+          %li.l-clearfix
+            = link_to '#', class: 'p-item_message_user' do
+              %figure
+                %div
+                  = image_tag 'common/member_photo_noimage_thumb.png'
+                %figcaption.u-fwBold
+                  りさ
+              .p-item_message_seller 出品者
+            .p-item_message_body
+              .p-item_message_body-text ありがとうございます！このままこちらからご購入ください。
+              .p-item_message_icons.l-clearfix
+                %time.p-item_message_icon-left
+                  %i.c-icon-time
+                  %span 4 日前
+                .p-item_message_icon-right
+                  = form_for '#', html: {class: 'c-message-form'} do |f|
+                    = button_tag '' do
+                      %i.c-icon-flag
+              %i.c-icon-balloon
+      .p-item_message_content
+        = form_for '#', html: {class: 'c-message-form'} do |f|
+          %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
+          = f.text_area :param_name, class: 'c-textarea-default'
+          = button_tag '#', class: 'p-message_submit c-btn-default is-gray' do
+            %span コメントする
+    %ul.p-item_nav-link.l-clearfix
+      %li.p-item_nav-link_prev
+        = link_to '/' do
+          %i.c-icon-arrow-left>
+          マグ＆スプーンセット  きのこ
+      %li.p-item_nav-link_next
+        = link_to '/' do
+          ★ちくわさん専用★エフデ ♡リボン スエード レザーグローブ♡手袋
+          %i.c-icon-arrow-right
+    .c-item_social-media-box
+      %ul.c-social-media-box
+        %li
+          = link_to '#', target: '_blank', class: 'c-share-btn' do
+            %i.c-icon-facebook
+        %li
+          = link_to '#', target: '_blank', class: 'c-share-btn' do
+            %i.c-icon-twitter
+        %li.social-hidden-item
+          = link_to '#', target: '_blank', class: 'c-share-btn' do
+            %i.c-icon-line
+        %li
+          = link_to '#', target: '_blank', class: 'c-share-btn' do
+            %i.c-icon-pinterest
+    .c-items-in-user-profile
+      %section.c-items-box_container.l-clearfix.c-items-box_overflow.c-items-in-user-profile
+        %h2.c-items-box_head
+          = link_to 'りささんのその他の出品', '#'
+        .c-items-box_content.l-clearfix
+          = render 'layouts/itembox',item: @other_items
+      %section.c-items-box_container.l-clearfix.c-items-box_overflow
+        %h2.c-items-box_head
+          = link_to '/brand/3117/791/' do
+            クリニークのチーク その他の商品
+        .c-items-box_content.l-clearfix
+          = render 'layouts/itembox',item: @other_items
+    = form_for '#', html: {id: 'report-item', class: 'c-modal mfp-hide'} do |f|
+      .c-modal_inner.c-modal_banner
+        .c-modal_body
+          .c-modal_head.u-fwBold 確認
+          不適切な商品を報告しますか？
+        .l-clearfix
+          .c-modal_btn.c-modal_btn-cancel.js-modal_btn-cancel キャンセル
+          = f.submit 'はい', class: 'c-modal_btn c-modal_btn-submit'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -151,15 +151,16 @@
     .c-items-in-user-profile
       %section.c-items-box_container.l-clearfix.c-items-box_overflow.c-items-in-user-profile
         %h2.c-items-box_head
-          = link_to 'りささんのその他の出品', '#'
+          = link_to '#' do
+            = @seller.nickname + "さんのその他の出品"
         .c-items-box_content.l-clearfix
           = render 'layouts/itembox',item: @other_items
       %section.c-items-box_container.l-clearfix.c-items-box_overflow
         %h2.c-items-box_head
           = link_to '/brand/3117/791/' do
-            クリニークのチーク その他の商品
+            = @brand.name + " " + @lower_category.name + " " + "その他の商品"
         .c-items-box_content.l-clearfix
-          = render 'layouts/itembox',item: @other_items
+          = render 'layouts/itembox',item: @other_brand_items
     = form_for '#', html: {id: 'report-item', class: 'c-modal mfp-hide'} do |f|
       .c-modal_inner.c-modal_banner
         .c-modal_body

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -12,7 +12,8 @@
           %tr
             %th 出品者
             %td
-              = link_to @seller.nickname
+              = link_to '#' do
+                = @seller.nickname
               %div
                 .p-item_user-ratings
                   %i.c-icon-good
@@ -43,8 +44,7 @@
             %th ブランド
             %td
               = link_to '/brand/3117/' do
-                %div
-                  = @brand.name
+                = @brand.name
           %tr
             %th 商品の状態
             %td
@@ -59,14 +59,15 @@
           %tr
             %th 配送元地域
             %td
-              = link_to @item.delivery_region
+              = link_to '/brand/3117/' do
+                = @item.delivery_region
           %tr
             %th 発送日の目安
             %td
               =@item.delivery_duration_i18n
     .p-item_price-box.u-taCenter
-      %span.p-item_price.u-fwBold ¥
-      = @item.buy_price
+      %span.p-item_price.u-fwBold
+        ¥#{@item.buy_price}
       %span.p-item_tax (税込)
       %span.p-item_shipping-fee
       = @item.delivery_payer_i18n
@@ -95,43 +96,29 @@
     .p-item_message_container
       .p-item_message_content
         %ul.p-item_message_block
-          %li.l-clearfix
-            = link_to '#', class: 'p-item_message_user' do
-              %figure
-                %div
-                  = image_tag 'common/member_photo_noimage_thumb.png'
-                %figcaption.u-fwBold
-                  はる
-            .p-item_message_body
-              .p-item_message_body-text 購入希望です^_^
-              .p-item_message_icons.l-clearfix
-                %time.p-item_message_icon-left
-                  %i.c-icon-time
-                  %span 4 日前
-                .p-item_message_icon-right
-                  = form_for '#', html: {class: 'c-message-form'} do |f|
-                    = button_tag '' do
-                      %i.c-icon-flag
-              %i.c-icon-balloon
-          %li.l-clearfix
-            = link_to '#', class: 'p-item_message_user' do
-              %figure
-                %div
-                  = image_tag 'common/member_photo_noimage_thumb.png'
-                %figcaption.u-fwBold
-                  りさ
-              .p-item_message_seller 出品者
-            .p-item_message_body
-              .p-item_message_body-text ありがとうございます！このままこちらからご購入ください。
-              .p-item_message_icons.l-clearfix
-                %time.p-item_message_icon-left
-                  %i.c-icon-time
-                  %span 4 日前
-                .p-item_message_icon-right
-                  = form_for '#', html: {class: 'c-message-form'} do |f|
-                    = button_tag '' do
-                      %i.c-icon-flag
-              %i.c-icon-balloon
+          - @item.transaction_messages.each do|message|
+            %li.l-clearfix
+              = link_to '#', class: 'p-item_message_user' do
+                %figure
+                  %div
+                    = image_tag 'common/member_photo_noimage_thumb.png'
+                  %figcaption.u-fwBold
+                    = message.user.nickname
+                - if message.user.id == @item.seller.id
+                  .p-item_message_seller 出品者
+              .p-item_message_body
+                .p-item_message_body-text
+                  = message.text
+                .p-item_message_icons.l-clearfix
+                  %time.p-item_message_icon-left
+                    %i.c-icon-time
+                    %span
+                      = time_ago_in_words(message.created_at)+"前"
+                  .p-item_message_icon-right
+                    = form_for '#', html: {class: 'c-message-form'} do |f|
+                      = button_tag '' do
+                        %i.c-icon-flag
+                %i.c-icon-balloon
       .p-item_message_content
         = form_for '#', html: {class: 'c-message-form'} do |f|
           %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。

--- a/app/views/layouts/_itembox.html.haml
+++ b/app/views/layouts/_itembox.html.haml
@@ -1,15 +1,15 @@
 %section.c-items-box
-  = link_to item_path(item) do
+  = link_to item_path(@item) do
     %figure.c-items-box_photo
-      = image_tag "#{item.pictures.find_by(status: 0).content}"
+      = image_tag "#{@item.pictures.find_by(status: 0).content}"
     .c-items-box_body
       %h3.c-items-box_name.c-font-2
-        = item.name
+        = @item.name
       .c-items-box_num.l-clearfix
         .c-items-box_price.c-font-5
-          = "¥ #{item.buy_price}"
+          = "¥ #{@item.buy_price}"
         .c-items-box_likes.c-font-2
-          = item.likes.length
+          = @item.likes.length
         %i.c-icon-like-border
         %span 1
         %p.c-item-box_tax (税込)

--- a/app/views/layouts/_itembox.html.haml
+++ b/app/views/layouts/_itembox.html.haml
@@ -11,5 +11,5 @@
         .c-items-box_likes.c-font-2
           = @item.likes.length
         %i.c-icon-like-border
-        %span 1
+        %span
         %p.c-item-box_tax (税込)

--- a/config/locales/item.ja.yml
+++ b/config/locales/item.ja.yml
@@ -10,7 +10,7 @@ ja:
         overall_bad_condition: '全体的に状態が悪い'
       delivery_payer:
         seller: '送料込み(出品者負担)'
-        buyer: '着払い(購入者負担)'
+        buyer: '送料着払い(購入者負担)'
       delivery_duration:
         one_to_two_days: '1~2日で発送'
         two_to_three_days: '2~3日で発送'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,3 +19,39 @@ ja:
         under_sale: '出品中'
         under_transaction: '取引中'
         sold_out: '売却済'
+  datetime:
+    distance_in_words:
+      half_a_minute: "30秒前後"
+      less_than_x_seconds:
+        one:   "1秒"
+        other: "%{count}秒"
+      x_seconds:
+        one:   "1秒"
+        other: "%{count}秒"
+      less_than_x_minutes:
+        one:   "1分"
+        other: "%{count}分"
+      x_minutes:
+        one:   "約1分"
+        other: "%{count}分"
+      about_x_hours:
+        one:   "約1時間"
+        other: "約%{count}時間"
+      x_days:
+        one:   "1日"
+        other: "%{count}日"
+      about_x_months:
+        one:   "約1ヶ月"
+        other: "約%{count}ヶ月"
+      x_months:
+        one:   "1ヶ月"
+        other: "%{count}ヶ月"
+      almost_x_years:
+        one:   "１年弱"
+        other: "%{count}年弱"
+      about_x_years:
+        one:   "約1年"
+        other: "約%{count}年"
+      over_x_years:
+        one:   "1年以上"
+        other: "%{count}年以上"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get 'descriptions/show'
+
   root 'items#index'
   devise_for :users, :controllers => {
   :registrations => 'users/registrations',
@@ -38,5 +40,9 @@ Rails.application.routes.draw do
   resources :addresses, only: [:index, :new, :create, :edit, :update]
   resources :phone_numbers, only: [:new, :create, :edit, :update]
   resources :credits, only: [:new, :create, :delete, :index]
+
+  resource :safe, only: [:show] do
+    resource :description,only: [:show]
+  end
 
 end


### PR DESCRIPTION
# what
出品商品の詳細ページを実装した

# why
・商品購入の意思決定前に、商品に関する詳細を確認するページが必要
・開発工程の都合により、商品詳細ページの表示部分を早めに実装する必要があり、
　（以下のNOTEに記載の通り、現状では未実装の機能があるが）必要項目を表示させられる段階で
　一旦プルリクエストさせていただきました。

# NOTE
・「配送方法」についてはdbの詳細を確認のうえで追加を検討することとする
・所持ポイント表示については、現状でユーザーの所持ポイントを登録する機能を想定していないため
　検討の上必要に応じて追加する
・「ブランド名 → 同ブランドの出品商品一覧」などの仕組みについては、「商品一覧」機能の実装に
　合わせて後ほど実装する（同ブランド一覧、同地域の出品一覧、ほか）
・SNSとの連携機能は別途実装することとする（現在は仮でSNSログインページへのパスを置いた）
・「安心安全宣言」ページはダミーページを置いた
・取引メッセージは今回の実装では表示のみとし、送信機能については別途実装する
・ランダムリンクについては、登録されているItemに応じてランダム表示させた。
　ただし仮の設定であり、今後、仕様の変更の可能性がある。

以上、よろしくお願いいたします。