### PR TITLE
商品詳細画面／いいね機能の実装　他

### DIFF
--- a/app/assets/stylesheets/p-item.scss
+++ b/app/assets/stylesheets/p-item.scss
@@ -143,7 +143,7 @@
   font-size: 10px;
 }
 .p-item_sales-point-message {
-  display: inline-block;
+  display: none;
   position: relative;
   line-height: 1.5;
   color: #fff;
@@ -188,6 +188,21 @@
   &.disabled {
     background: #888;
     cursor: not-allowed;
+  }
+}
+.p-item_buy-btn_sold {
+  display: block;
+  height: 56px;
+  margin: 16px 0 0;
+  background: gray;
+  color: #fff;
+  line-height: 56px;
+  text-align: center;
+  font-weight: 600;
+
+  @include media-pc {
+    height: 60px;
+    line-height: 60px;
   }
 }
 .p-item_description {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -30,14 +30,7 @@ class ItemsController < ApplicationController
     @lower_category = LowerCategory.find(@item.lower_category_id)
     @sizes = Size.find(@item.size_id)
     random_page_link
-
-
-    @like = Like.find_by(user_id: current_user.id, item_id: params[:item_id])
     @likes = Like.where(item_id: params[:item_id])
-    @items = Item.all
-
-
-
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -30,6 +30,14 @@ class ItemsController < ApplicationController
     @lower_category = LowerCategory.find(@item.lower_category_id)
     @sizes = Size.find(@item.size_id)
     random_page_link
+
+
+    @like = Like.find_by(user_id: current_user.id, item_id: params[:item_id])
+    @likes = Like.where(item_id: params[:item_id])
+    @items = Item.all
+
+
+
   end
 
   def new

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,21 +1,14 @@
 class LikesController < ApplicationController
 
   def create
-    @like = Like.create(user_id: current_user.id,item_id: params[:item_id])
-
+    @like = Like.create(user_id: current_user.id, item_id: params[:item_id])
     @likes = Like.where(item_id: params[:item_id])
     @item = Item.find(params[:item_id])
-    @items = Item.all
-
   end
 
   def destroy
     @like = Like.find_by(user_id: current_user.id, item_id: params[:item_id]).destroy
-
-    @likes = Like.where(item_id: params[:item_id])
     @item = Item.find(params[:item_id])
-    @items = Item.all
-
   end
 
 end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,11 @@
+class LikesController < ApplicationController
+
+  def create
+    @like = Like.create(user_id: current_user.id,item_id: params[:item_id])
+  end
+
+  def destroy
+    @like = Like.find_by(user_id: current_user.id, item_id: params[:item_id]).destroy
+  end
+
+end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -2,10 +2,20 @@ class LikesController < ApplicationController
 
   def create
     @like = Like.create(user_id: current_user.id,item_id: params[:item_id])
+
+    @likes = Like.where(item_id: params[:item_id])
+    @item = Item.find(params[:item_id])
+    @items = Item.all
+
   end
 
   def destroy
     @like = Like.find_by(user_id: current_user.id, item_id: params[:item_id]).destroy
+
+    @likes = Like.where(item_id: params[:item_id])
+    @item = Item.find(params[:item_id])
+    @items = Item.all
+
   end
 
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -84,8 +84,8 @@
         = @item.description
     .p-item_button-container.l-clearfix
       .c-item-button-left
-        #like_btn
-          = render partial: "likes/like", locals: { item: @item, items: @items, like: @like, likes: @likes }
+        #like_btn.c-item-button
+          = render partial: "likes/like", locals: { item: @item, likes: @likes }
         = link_to '#report-item', class: 'c-item-button c-item-button-report l-clearfix js-modal' do
           %i.c-icon-flag
           %span 不適切な商品の報告

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -84,11 +84,8 @@
         = @item.description
     .p-item_button-container.l-clearfix
       .c-item-button-left
-        = button_tag class: 'c-item-button c-item-button-like' do
-          %i.c-icon-like-border
-          %span いいね!
-          %span.is-fade-in-down
-            = @item.like_count
+        #like_btn
+          = render "likes/like", item: @item
         = link_to '#report-item', class: 'c-item-button c-item-button-report l-clearfix js-modal' do
           %i.c-icon-flag
           %span 不適切な商品の報告

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -85,7 +85,7 @@
     .p-item_button-container.l-clearfix
       .c-item-button-left
         #like_btn
-          = render "likes/like", item: @item
+          = render partial: "likes/like", locals: { item: @item, items: @items, like: @like, likes: @likes }
         = link_to '#report-item', class: 'c-item-button c-item-button-report l-clearfix js-modal' do
           %i.c-icon-flag
           %span 不適切な商品の報告

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -74,7 +74,11 @@
     .u-taCenter
       .p-item_sales-point-message
         P 500 をお持ちです
-    = link_to '購入画面に進む',edit_item_buy_path(@item), class: 'p-item_buy-btn u-fz18-24'
+    - if @item.transaction_stage == "under_sale"
+      = link_to '購入画面に進む',edit_item_buy_path(@item), class: 'p-item_buy-btn u-fz18-24'
+    - else
+      .p-item_buy-btn_sold.u-fz18-24
+        売り切れです
     .p-item_description.u-fz14
       %p.p-item_description-inner
         = @item.description

--- a/app/views/likes/_like.html.haml
+++ b/app/views/likes/_like.html.haml
@@ -1,12 +1,15 @@
 - if user_signed_in?
   - if item.likes.find_by(user_id: current_user.id)
-    = button_to item_like_path(item_id: item.id), method: :delete, class: "c-item-button c-item-button-like", remote: true do
+
+    = button_to item_like_path(item_id: item.id), method: :delete,class: "c-item-button c-item-button-like", remote: true do
       %i.c-icon-like-border
       %span いいね!
       %span.is-fade-in-down
         = item.like_count
+
   - else
-    = button_to item_likes_path(item.id), class: "c-item-button c-item-button-like", remote: true do
+
+    = button_to item_likes_path(item_id: item.id), class: "c-item-button c-item-button-like", remote: true do
       %i.c-icon-like-border
       %span いいね!
       %span.is-fade-in-down

--- a/app/views/likes/_like.html.haml
+++ b/app/views/likes/_like.html.haml
@@ -1,14 +1,11 @@
 - if user_signed_in?
   - if item.likes.find_by(user_id: current_user.id)
-
-    = button_to item_like_path(item_id: item.id), method: :delete,class: "c-item-button c-item-button-like", remote: true do
-      %i.c-icon-like-border
+    = button_to item_like_path(likes, item_id: item.id), method: :delete, class: "c-item-button c-item-button-like", remote: true do
+      %i.c-icon-like
       %span いいね!
       %span.is-fade-in-down
         = item.like_count
-
   - else
-
     = button_to item_likes_path(item_id: item.id), class: "c-item-button c-item-button-like", remote: true do
       %i.c-icon-like-border
       %span いいね!
@@ -20,7 +17,3 @@
     %span いいね!
     %span.is-fade-in-down
       = @item.like_count
-
-
-
-

--- a/app/views/likes/_like.html.haml
+++ b/app/views/likes/_like.html.haml
@@ -1,0 +1,23 @@
+- if user_signed_in?
+  - if item.likes.find_by(user_id: current_user.id)
+    = button_to item_like_path(item_id: item.id), method: :delete, class: "c-item-button c-item-button-like", remote: true do
+      %i.c-icon-like-border
+      %span いいね!
+      %span.is-fade-in-down
+        = item.like_count
+  - else
+    = button_to item_likes_path(item.id), class: "c-item-button c-item-button-like", remote: true do
+      %i.c-icon-like-border
+      %span いいね!
+      %span.is-fade-in-down
+        = item.like_count
+- else
+  = button_tag class: 'c-item-button c-item-button-like' do
+    %i.c-icon-like-border
+    %span いいね!
+    %span.is-fade-in-down
+      = @item.like_count
+
+
+
+

--- a/app/views/likes/create.js.erb
+++ b/app/views/likes/create.js.erb
@@ -1,1 +1,1 @@
-$("#like_btn").html("<%= j(render "likes/like", item: @item) %>");
+$("#like_btn").html("<%= j(render partial: "likes/like", locals: { item: @item, items: @items, like: @like, likes: @likes }) %>");

--- a/app/views/likes/create.js.erb
+++ b/app/views/likes/create.js.erb
@@ -1,0 +1,1 @@
+$("#like_btn").html("<%= j(render "likes/like", item: @item) %>");

--- a/app/views/likes/create.js.erb
+++ b/app/views/likes/create.js.erb
@@ -1,1 +1,1 @@
-$("#like_btn").html("<%= j(render partial: "likes/like", locals: { item: @item, items: @items, like: @like, likes: @likes }) %>");
+$("#like_btn").html("<%= j(render partial: "likes/like", locals: { item: @item, like: @like, likes: @likes }) %>");

--- a/app/views/likes/destroy.js.erb
+++ b/app/views/likes/destroy.js.erb
@@ -1,1 +1,1 @@
-$("#like_btn").html("<%= j(render "likes/like", item: @item) %>");
+$("#like_btn").html("<%= j(render partial: "likes/like", locals: { item: @item, items: @items, like: @like, likes: @likes }) %>");

--- a/app/views/likes/destroy.js.erb
+++ b/app/views/likes/destroy.js.erb
@@ -1,0 +1,1 @@
+$("#like_btn").html("<%= j(render "likes/like", item: @item) %>");

--- a/app/views/likes/destroy.js.erb
+++ b/app/views/likes/destroy.js.erb
@@ -1,1 +1,1 @@
-$("#like_btn").html("<%= j(render partial: "likes/like", locals: { item: @item, items: @items, like: @like, likes: @likes }) %>");
+$("#like_btn").html("<%= j(render partial: "likes/like", locals: { item: @item, like: @like }) %>");

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  get 'likes/create'
+
+  get 'likes/destroy'
+
   get 'descriptions/show'
 
   root 'items#index'


### PR DESCRIPTION
# WHAT
１）商品詳細ページにて「いいね機能」を実装した
２）商品購入ページへ遷移する「商品を購入する」ボタンについて、
　　既に販売済みの商品についてはボタンクリックが出来ない様に変更した
 
# WHY
１）商品への「いいね」評価を行うため
２）現状では販売済み商品も商品購入ページに入ることができ紛らわしい
　　マスクすることで販売済み商品の購入ページに入ってしまうことを防止する

# ポイント
１）「いいね機能」
　・likeテーブルへのcreateアクションとdeleteアクションを作成した
　・ログイン中ユーザーが、選択アイテムへlikeしているかどうかで条件分岐した
　・likeしている場合はdelete、していない場合はcreateアクションを動作する様に、
　　それぞれのルーティングを設定し、renderで部分テンプレートにした
　・delete/createアクション動作後にdelete/create.jsを発火させる
　　.html（render・・）でrenderさせることで上記の条件分岐まで表示を戻す
　・上記をremote:trueにより非同期で実行させた

２）販売済み商品の場合の、商品購入ボタンの仕様変更
　・itemテーブルのtransaction_stage（取引状況）カラムを参照し条件分岐した
　・SCCを変更し、販売済みの場合は「灰色」「リンクなし」「（表示）売り切れです」
　　の状態にした