### PR TITLE
取引用コメント（transaction_message）の投稿・表示機能の実装　他

### DIFF
--- a/app/assets/stylesheets/_component.scss
+++ b/app/assets/stylesheets/_component.scss
@@ -745,7 +745,7 @@ i {
   background-repeat: no-repeat;
   background-position: center center;
   background-size: cover;
-  
+
   .p-search_container &,
   .category-brand-list & {
     width: 100%;
@@ -1102,4 +1102,11 @@ i {
       float: left;
       margin: 16px 16px 0 0;
     }
+}
+.alert-text {
+  color: #ea352d;
+  line-height: 50px ;
+  font-size: 16px;
+  text-align: center;
+  background-color:#F0FFF0;
 }

--- a/app/assets/stylesheets/_component.scss
+++ b/app/assets/stylesheets/_component.scss
@@ -745,7 +745,6 @@ i {
   background-repeat: no-repeat;
   background-position: center center;
   background-size: cover;
-
   .p-search_container &,
   .category-brand-list & {
     width: 100%;

--- a/app/controllers/buys_controller.rb
+++ b/app/controllers/buys_controller.rb
@@ -35,7 +35,7 @@ class BuysController < ApplicationController
     redirect_to root_path, alert: "既に販売済みの商品です" unless @item.transaction_stage == "under_sale"
   end
   def confirm_user_sign_in
-    redirect_to root_path, alert: "ログインして下さい" unless user_signed_in?
+    redirect_to new_user_session_path, alert: "ログインして下さい" unless user_signed_in?
   end
 
 end

--- a/app/controllers/credits_controller.rb
+++ b/app/controllers/credits_controller.rb
@@ -13,7 +13,6 @@ include Payjp_process
   end
 
   def create
-    if user_signed_in?
       unless current_user.credits.present?
       @credit = Credit.create(credit_params)
         if @credit.save
@@ -24,9 +23,6 @@ include Payjp_process
       else
         redirect_to new_credit_path, alert: "既に登録されています"
       end
-    else
-      redirect_to root_path, alert: "ログインしてください"
-    end
   end
 
   def destroy
@@ -46,7 +42,7 @@ include Payjp_process
   end
 
   def confirm_user_sign_in
-    redirect_to root_path, alert: "ログインして下さい" unless user_signed_in?
+    redirect_to new_user_session_path, alert: "ログインして下さい" unless user_signed_in?
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -32,6 +32,7 @@ class ItemsController < ApplicationController
     @sizes = Size.find(@item.size_id)
     # random_page_link
     @likes = Like.where(item_id: params[:item_id])
+    @transaction_message = TransactionMessage.new
   end
 
   def new

--- a/app/controllers/transaction_messages_controller.rb
+++ b/app/controllers/transaction_messages_controller.rb
@@ -1,14 +1,15 @@
 class TransactionMessagesController < ApplicationController
   before_action :move_to_sign_in
   before_action :set_item_and_transaction_messages
-  before_action :confirm_buyer_or_seller_include_current_user
-  before_action :confirm_transaction_stage_under_transaction
+#  before_action :confirm_buyer_or_seller_include_current_user, except: :create
+#  before_action :confirm_transaction_stage_under_transaction, except: :create
 
   def index
   end
 
   def create
     @created_transaction_message = TransactionMessage.create(transaction_message_params)
+    redirect_to item_path(@item.id)
   end
 
   private

--- a/app/controllers/transaction_messages_controller.rb
+++ b/app/controllers/transaction_messages_controller.rb
@@ -9,7 +9,7 @@ class TransactionMessagesController < ApplicationController
 
   def create
     @created_transaction_message = TransactionMessage.create(transaction_message_params)
-    redirect_to item_path(@item.id)
+    redirect_to item_path(@item.id) ,notice: 'メッセージを投稿しました'
   end
 
   private

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,5 +1,5 @@
 .l-default-container
-  %h2.c-has-error-text
+  .alert-text
     = flash[:notice]
   %section.p-item_box-container.l-single_container
     %h1.p-item_name

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -121,10 +121,10 @@
                         %i.c-icon-flag
                 %i.c-icon-balloon
       .p-item_message_content
-        = form_for '#', html: {class: 'c-message-form'} do |f|
+        = form_for [@item,@transaction_message] , html: {class: 'c-message-form'} do |f|
           %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
-          = f.text_area :param_name, class: 'c-textarea-default'
-          = button_tag '#', class: 'p-message_submit c-btn-default is-gray' do
+          = f.text_area :text, class: 'c-textarea-default'
+          = f.submit 'コメントする', class: 'p-message_submit c-btn-default is-gray' do
             %span コメントする
     -# %ul.p-item_nav-link.l-clearfix
     -#   %li.p-item_nav-link_prev

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,4 +1,6 @@
 .l-default-container
+  %h2.c-has-error-text
+    = flash[:notice]
   %section.p-item_box-container.l-single_container
     %h1.p-item_name
       = @item.name


### PR DESCRIPTION
# WHAT

１）取引間のコメントの投稿と表示機能を、商品詳細ページに実装した

２）（credit/buy_controller）未ログイン時の処理を修正

# WHY

１）コメント入力欄の表示、並びにdbへの投稿機能は先立って実装されていたが、
　　実際に投稿する機能がviewに実装されていなかったため

２）未ログイン時にリダイレクトさせる処理「confirm_user_sign_in」メソッドについて、　　　
　　credit_controllerで利用できていなかった箇所を修正した。
　　また（加えてbuy_controllerでも）リダイレクト先がroot_pathだったので、
　　ログインページにリダイレクトするように修正した。　

# ポイント

１）取引間コメントの投稿と表示について
　・item_controller/showアクションにてtransaction_messsageのインスタンス生成
　・item/show.html.hamlファイルにて、form_forでコメントをdbに送るpathを記述
　・transaction_message_controllerにて、登録後に商品詳細ページへのredirectを追加
　・redirect後に「投稿しました」のフラッシュメッセージ表示を追加（item/show.html.haml）

２）未ログイン処理について
　・コミットの内容をご参照ください

以上