### PR TITLE
発送地域別の商品一覧の実装

### DIFF
--- a/app/controllers/areas_controller.rb
+++ b/app/controllers/areas_controller.rb
@@ -1,0 +1,9 @@
+class AreasController < ApplicationController
+
+  def index
+    @region_params = params[:region]
+    @items = Item.where(delivery_region: @region_params).includes(:pictures)
+  end
+
+
+end

--- a/app/views/areas/index.html.haml
+++ b/app/views/areas/index.html.haml
@@ -1,0 +1,21 @@
+.l-container
+  = @items.first.delivery_region
+  の商品一覧
+  .c-items-box_container.l-clearfix
+    %ul.c-parts-nav.l-clearfix
+      - @items.each do |item|
+        %section.c-items-box
+          = link_to item_path(item) do
+            %figure.c-items-box_photo{style: "background-image: url(#{item.pictures.first.content})"}
+            .c-items-box_body
+              %h3.c-items-box_name.c-font-2
+                = item.name
+              .c-items-box_num.l-clearfix
+                .c-items-box_price.c-font-5
+                  ¥
+                  = item.buy_price
+                .c-items-box_likes.c-font-2
+                  %i.c-icon-like-border
+                  %span
+                    = item.like_count
+                %p.c-item-box_tax (税込)

--- a/app/views/credits/index.html.haml
+++ b/app/views/credits/index.html.haml
@@ -18,7 +18,8 @@
                   = @credit_data.exp_month
                   \/
                   = @credit_data.exp_year
-                  = link_to '削除する',credit_path(@credit_data.id),method: :delete,class:"credit_delete_btn"
+                  = link_to '削除する',credit_path(@credit_data.id),method: :delete,class:"credit_delete_btn", data:{confirm:"本当に削除してもよろしいでしょうか？"}
+
         %section.transact-select-card-footer
           .l-single_content
             = link_to '次に進む' ,:back,  class: 'c-btn-default is-red'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -61,7 +61,7 @@
           %tr
             %th 配送元地域
             %td
-              = link_to items_path do
+              = link_to areas_path(region: @item.delivery_region) do
                 = @item.delivery_region
           %tr
             %th 発送日の目安

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
 
   resources :groups, only: [:show]
   resources :brands, only: [:show]
+  resources :area, only: [:show]
 
   resources :upper_categories, only: [:index, :show]
   resources :middle_categories, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
 
   resources :groups, only: [:show]
   resources :brands, only: [:show]
-  resources :area, only: [:show]
+  resources :areas, only: [:index]
 
   resources :upper_categories, only: [:index, :show]
   resources :middle_categories, only: [:show]


### PR DESCRIPTION
# WHAT
・商品出品者の発送元地域をベースに、発送地域別での商品一覧を表示する機能を実装した

# WHY
・送料を抑えたい、手渡しで対応したい、といった利用者ニーズに対応するため

# ポイント
・商品詳細画面（item/show）から、itemテーブルのdelivery_region（地域）をparamsとして送る

# note
・（views/credits/index.html.haml）の修正は、発送地域別・・の機能とは関係なく、
　クレジットカード情報を削除した際にアラートを表示する動作を追加した。
　本筋と異なる修正を混在させてしまい申し訳ございませんが併せてお願いします。

以上