### PR TITLE
Develop resolve n+1 problem in brands

### DIFF
--- a/app/assets/stylesheets/_p-category.scss
+++ b/app/assets/stylesheets/_p-category.scss
@@ -122,6 +122,7 @@
   border-radius: 4px;
 }
 .brand-list-initial-box {
+  clear: both;
   @include media-pc {
     padding-bottom: 10px;
   }
@@ -135,9 +136,13 @@
   padding: 10px 30px;
 }
 .brand-list-initial-box-brand-list {
-
+  background-color: white;
   @include media-pc {
     padding: 10px 50px;
+    float: left;
+    width: 50%;
+    padding: 10px 20px 10px 0;
+    border: 0;
   }
 
   a {
@@ -145,12 +150,6 @@
     padding: 10px 20px 10px;
     border-bottom: 1px solid #eee;
 
-    @include media-pc {
-      float: left;
-      width: 50%;
-      padding: 10px 20px 10px 0;
-      border: 0;
-    }
   }
   p {
     font-size: 16px;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -4,12 +4,26 @@ class GroupsController < ApplicationController
 
   def show
     @groups = Group.eager_load(:brands)
-    @initials = @group.brands.group(:initial_word)
     @brands = @group.brands
+    @ununique_initials = @brands.pluck(:initial_word)
+    @initials = @ununique_initials.uniq
+    find_border_of_different_initial
   end
 
   private
+
   def set_group
     @group = Group.find(params[:id])
+  end
+
+  def find_border_of_different_initial
+    @initial_index =[]
+    @previous_initial = nil
+    @ununique_initials.each_with_index do |ununique_initial, index|
+      if @previous_initial != ununique_initial
+        @initial_index << index
+        @previous_initial = ununique_initial
+      end
+    end
   end
 end

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -13,20 +13,20 @@
     .l-visiblePc.brand-initial-link-box.l-clearfix
       - @initials.each do |initial|
         .brand-initial-link-box-initial.slide-nav-parent
-          = link_to "#initial-#{initial.initial_word}", data: {turbolinks: false}, class: "js-scroll"  do
-            = initial.initial_word
+          = link_to "#initial-#{initial}", data: {turbolinks: false}, class: "js-scroll"  do
+            = initial
     .category-list-box
       .category-list-individual-box.u-bgWt.l-clearfix
         .u-bgRd.u-clWt.category-list-individual-box-root-category-name
           %h3#root_category-1
             = @group.name
-        .brand-list-box
-          - @initials.each do |initial|
-            .brand-list-initial-box.white.l-clearfix{id: "initial-#{initial.initial_word}"}
-              .brand-list-initial-box-initial.u-bgDgy
-                %h4
-                  = initial.initial_word
-              .brand-list-initial-box-brand-list.l-clearfix
-                - @brands.where(initial_word: initial.initial_word).each do |brand|
-                  = link_to brand_path(brand) do
-                    = brand.name
+        .brand-list-box.l-clearfix
+          - @brands.each_with_index do |brand, index|
+            - if @initial_index.include?(index)
+              .brand-list-initial-box.white{id: "initial-#{brand.initial_word}"}
+                .brand-list-initial-box-initial.u-bgDgy
+                  %h4
+                    = brand.initial_word
+            .brand-list-initial-box-brand-list.l-clearfix
+              = link_to brand_path(brand) do
+                = brand.name


### PR DESCRIPTION
## what
ブランド一覧ページにて発生していたN+1問題を解消した。

brandテーブルのもつinitial_wordコラム毎にbrandを呼び出し、
each文を用いて表示していたためにSQLが大量発行されていた。

- @initials.each do |initial|
　- @brands.where(initial_word: initial.initial_word).each do |brand|

この問題に対して、initial_wordのみをハッシュで抜き出した際に、
initial_wordが変化する時のindex番号をcontrollerであらかじめ取得し、(@initial_index)
viewでは、brands全体に対するeach文の中でif文を用いて、取得したindex番号の時だけ
.brand-list-initial-boxが表示されるようにした。

before
<img width="1391" alt="freemarket_sample_36a_ _fsevent_watch_ _localhost_3000___freemarket_sample_36a__rbenv_version_2_5_1_term_program_apple_terminal_ _204x63" src="https://user-images.githubusercontent.com/44108156/52789116-5b8a3780-30a6-11e9-9ca4-07b9bdbbf306.png">

after
<img width="1439" alt="freemarket_sample_36a_ _fsevent_watch_ _localhost_3000___freemarket_sample_36a__rbenv_version_2_5_1_term_program_apple_terminal_ _204x63" src="https://user-images.githubusercontent.com/44108156/52789152-6d6bda80-30a6-11e9-8b5e-bec2cb1d68cb.png">

view
<img width="789" alt="freemarketsample36a" src="https://user-images.githubusercontent.com/44108156/52789824-53cb9280-30a8-11e9-8316-e1c11a33eb13.png">


## why
SQLを大量発行することは、アクセス速度を落とすとともに、
AWSでのリクエスト回数増加に伴うサーバ維持コストの増加に繋がる。

## future
initial_wordでbrandsをあいうえお順にソートしてから処理する関数を途中に挟むことで、
今後、brandsテーブルに変更や追加があった際も順番通りに表示される。