### PR TITLE
reCAPTCHAの導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'omniauth-facebook'
 gem 'omniauth-twitter'
 gem 'omniauth-google-oauth2'
 gem 'omniauth-instagram'
+gem "recaptcha"
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,8 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     rdoc (4.3.0)
+    recaptcha (4.13.1)
+      json
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -410,6 +412,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.7)
   rails (= 5.1.6)
+  recaptcha
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,4 +1,5 @@
 class Users::RegistrationsController < Devise::RegistrationsController
+  prepend_before_action :check_captcha, only: [:create]
   layout "single"
 
   def select_api
@@ -15,5 +16,14 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
   def update_resource(resource, params)
     resource.update_without_password(params)
+  end
+
+  def check_captcha
+    unless verify_recaptcha
+      self.resource = resource_class.new sign_up_params
+      resource.validate
+      set_minimum_password_length
+      respond_with resource
+    end
   end
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -25,4 +25,6 @@
             %span.c-form_require 必須
             = f.password_field :password_confirmation, placeholder: '6文字以上', class: 'c-input-default'
           .c-form_group
+            = recaptcha_tags
+          .c-form_group
             = f.submit '次へ進む', class: 'c-btn-default is-red'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -8,21 +8,25 @@
           = avatar.hidden_field :content
         .l-single_content
           .c-form_group
-            = f.label :nickname, 'ニックネーム'
-            %span.c-form_require 必須
+            = f.label :nickname do
+              ニックネーム
+              %span.c-form_require 必須
             = f.text_field :nickname, autofocus: true, placeholder: '例）メルカリ太郎', class: 'c-input-default'
           .c-form_group
-            = f.label :email, 'メールアドレス'
-            %span.c-form_require 必須
+            = f.label :email do
+              メールアドレス
+              %span.c-form_require 必須
             = f.email_field :email, autofocus: true, placeholder: 'PC・携帯どちらでも可', class: 'c-input-default'
             %p.u-clRd 登録されたメールアドレスに認証メールが送信されます
           .c-form_group
-            = f.label :password, 'パスワード'
-            %span.c-form_require 必須
+            = f.label :password do
+              パスワード
+              %span.c-form_require 必須
             = f.password_field :password, placeholder: '6文字以上', class: 'c-input-default'
           .c-form_group
-            = f.label :password_confirmation, 'パスワード（確認）'
-            %span.c-form_require 必須
+            = f.label :password_confirmation do
+              パスワード（確認）
+              %span.c-form_require 必須
             = f.password_field :password_confirmation, placeholder: '6文字以上', class: 'c-input-default'
           .c-form_group
             = recaptcha_tags

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,0 +1,4 @@
+Recaptcha.configure do |config|
+  config.site_key = ENV["RECAPTCHA_SITE_KEY"]
+  config.secret_key = ENV["RECAPTCHA_SECRET_KEY"]
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -62,3 +62,6 @@ ja:
       over_x_years:
         one:   "1年以上"
         other: "%{count}年以上"
+    recaptcha:
+      errors:
+        verification_failed: 'reCAPTCHA認証に失敗しました。' 


### PR DESCRIPTION
# What
## ユーザー新規登録ページにreCAPTCHAを導入した

(1) Gemfile　→　Gemを追記
(2) devise/registrations/new.html.haml　→　viewにreCAPTCHAタグを追記
(3) users/registrations_controller.rb　→　コントローラーを設定
(4) config/locales/ja.yml　→　エラー文を追記

# Why
## セキュリティの向上、BOT対策として

(1) 本サイトと同様にv2を導入
(2) フォームにタグを追記
(3) 新規登録時にreCAPTCHAによるチェックを行う
(4) エラー文の日本語設定

![localhost_3000_users_sign_up](https://user-images.githubusercontent.com/39951170/52861036-8fcc2980-3174-11e9-8d3b-a6bdd7870628.png)


