### PR TITLE
商品検索Lv1（あいまい検索）の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -79,6 +79,12 @@ class ItemsController < ApplicationController
     redirect_to root_path, notice: 'Item was successfully destroyed.'
   end
 
+  def search
+    @items = Item.where("name LIKE(?) OR description LIKE(?)","%#{params[:keyword]}%", "%#{params[:keyword]}%").order("created_at DESC").page(params[:page]).per(48).includes(:pictures)
+    @new_items = Item.order("created_at DESC").limit(24).includes(:pictures)
+    render :search, layout: "search"
+  end
+
   private
 
     def set_item

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -1,0 +1,19 @@
+- breadcrumb :search, @search
+.l-content
+  %section
+    %section.c-items-box_container.l-clearfix
+      %h2.p-search_result-head
+        検索結果
+        = page_entries_info @items
+        件
+      - if @items.length == 0
+        %p.p-search_result-description
+          該当する商品が見つかりません。商品は毎日増えていますので、これからの出品に期待してください。
+        %h3.c-items-box_head
+          新着商品
+        .c-items-box_content.l-clearfix
+          = render partial: 'layouts/item', collection: @new_items
+      - else
+        .c-items-box_content.l-clearfix
+          = render partial: 'layouts/item', collection: @items
+      = paginate @items, window: 2

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -9,9 +9,10 @@
           %div
             = image_tag 'common/member_photo_noimage_thumb.png', width: '32'
   .l-search_bar
-    = form_tag '/search/', class: 'l-headerSp_form' do
-      = search_field_tag :keyword, params[:keywords], placeholder: '何をお探しですか？', class: 'l-headerSp_search c-input-default'
-      %i.c-icon-search
+    = form_with url: search_items_path, method: :get, local: true, class: 'l-headerSp_form' do |f|
+      = f.text_field :keyword, placeholder: '何をお探しですか？', class: 'l-headerSp_search c-input-default'
+      = button_tag type: 'submit' do
+        %i.c-icon-search
   %nav.l-headerSp_nav.l-search-links
     = link_to 'カテゴリから探す', upper_categories_path
     = link_to 'ブランドから探す', group_path(1)
@@ -21,9 +22,10 @@
       %h1.l-flLeft
         = link_to root_path do
           = image_tag 'common/logo.svg', alt: 'mercari', width: '134', height: '36'
-      = form_tag '/search/', class: 'l-headerPc_form l-flRight' do
-        = search_field_tag :keyword, params[:keywords], placeholder: 'キーワードから探す', class: 'c-input-default'
-        %i.c-icon-search
+      = form_with url: search_items_path, method: :get, local: true, class: 'l-headerPc_form l-flRight' do |f|
+        = f.text_field :keyword, placeholder: '何をお探しですか？', class: 'c-input-default'
+        = button_tag type: 'submit' do
+          %i.c-icon-search
     .l-headerPc_nav-box.l-clearfix
       %nav.l-flLeft
         %ul.l-headerPc_nav

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -31,3 +31,9 @@ crumb :brand do |brand|
   link brand.name, brand_path(brand)
   parent :group, brand
 end
+
+crumb :search do |search|
+  @keyword = params[:keyword]
+  link @keyword
+  parent :root
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -78,3 +78,12 @@ ja:
   recaptcha:
     errors:
       verification_failed: 'reCAPTCHA認証に失敗しました。'
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: "0"
+          one: "1"
+          other: "%{count}"
+      more_pages:
+        display_entries: "%{first}-%{last}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,9 @@ Rails.application.routes.draw do
     resources :transaction_messages, only: [:index, :create]
     resource :buy, only: [:edit,:update]
     resources :information, only: [:create]
+    collection do
+      get :search
+    end
   end
 
   resources :groups, only: [:show]
@@ -48,5 +51,4 @@ Rails.application.routes.draw do
   resource :safe, only: [:show] do
     resource :description,only: [:show]
   end
-
 end


### PR DESCRIPTION
# What
## 商品検索Lv1（あいまい検索）を実装した

(1) route.rb　→　ルーティングを作成
(2) items_controller.rb　→　コントローラーを作成
(3) views/layouts/_header.html.haml　→　ヘッダーの検索フォームを変更
(4) views/items/search.html.haml　→　検索結果ページのhtmlを作成
(5) config/locales/ja.yml　→　検索結果の表示設定を作成
(6) config/breadcrumbs.rb　→　パンくずの表示設定を作成

# Why
## ユーザーの商品へのアクセシビリティを高めるため

(1) 商品を検索するためitem配下に置いた
(2) 検索は本サイトと同様に商品名と説明文を対象とした
(3) 検索フォームのタグを変更した（form_withを使用)
(4) 本サイトと同様に検索結果が0の場合は固定テキストと新着商品を表示した
(5) kaminariを利用して検索結果の表示設定を作成した
(6) 本サイトと同様に検索ワードが入るようパンくずの表示を作成した

※サイドメニューの実装はすべて次回（Lv2）で行うこととした

![localhost_3000_items_search_utf8 e2 9c 93 keyword nike button 1](https://user-images.githubusercontent.com/39951170/52913244-8c18de00-32ff-11e9-83f7-5fa001904753.png)
