### PR TITLE
ランダムページリンクの修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,7 +33,7 @@ class ItemsController < ApplicationController
     @middle_category = @item.middle_category
     @lower_category = @item.lower_category
     @size = @item.size
-    # random_page_link
+    random_page_link
     @likes = @item.likes
     @comment = Comment.new
     @comments = @item.comments.includes(:user)
@@ -170,14 +170,14 @@ class ItemsController < ApplicationController
       end
     end
 
-    # def random_page_link
-    #   #ランダムなページリンクを生成する
-    #   rand_ranges = Item.all.count
-    #   random = Random.new
-    #   @rand_next = random.rand(rand_ranges)+1
-    #   @next_page = Item.find(@rand_next)
-    #   @rand_prev = random.rand(rand_ranges)+1
-    #   @prev_page = Item.find(@rand_prev)
-    # end
+     def random_page_link
+       rand_ranges = Item.all.count
+       random_next = Random.new
+       @rand_next = random_next.rand(rand_ranges)+1
+       @next_page = Item.find(@rand_next)
+       random_prev = Random.new
+       @rand_prev = random_prev.rand(rand_ranges)+1
+       @prev_page = Item.find(@rand_prev)
+     end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,10 +33,10 @@ class ItemsController < ApplicationController
     @middle_category = @item.middle_category
     @lower_category = @item.lower_category
     @size = @item.size
-    random_page_link
     @likes = @item.likes
     @comment = Comment.new
     @comments = @item.comments.includes(:user)
+    random_page_link
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,7 +36,9 @@ class ItemsController < ApplicationController
     @likes = @item.likes
     @comment = Comment.new
     @comments = @item.comments.includes(:user)
-    random_page_link
+    if Item.any?
+      random_page_link
+    end
   end
 
   def new

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -113,7 +113,7 @@
                   %figcaption.u-fwBold
                     = message.user.nickname
                 - if message.user.id == @item.seller.id
-                  .p-item_message_seller 出品者
+                  .p-item_message_seller-self 出品者
               .p-item_message_body
                 .p-item_message_body-text
                   = message.text
@@ -135,13 +135,13 @@
             %span コメントする
     %ul.p-item_nav-link.l-clearfix
       %li.p-item_nav-link_prev
-        = link_to "#{@rand_prev}" do
+        = link_to item_path(@prev_page) do
           %i.c-icon-arrow-left>
-          -# = @next_page.name
+          = @prev_page.name
       %li.p-item_nav-link_next
-        = link_to '#{@rand_next}' do
+        = link_to item_path(@next_page) do
           %i.c-icon-arrow-right
-          -# = @next_page.name
+          = @next_page.name
     .c-item_social-media-box
       %ul.c-social-media-box
         %li

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -113,7 +113,7 @@
                   %figcaption.u-fwBold
                     = message.user.nickname
                 - if message.user.id == @item.seller.id
-                  .p-item_message_seller-self 出品者
+                  .p-item_message_seller 出品者
               .p-item_message_body
                 .p-item_message_body-text
                   = message.text

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -134,14 +134,15 @@
           = button_tag '#', class: 'p-message_submit c-btn-default is-gray' do
             %span コメントする
     %ul.p-item_nav-link.l-clearfix
-      %li.p-item_nav-link_prev
-        = link_to item_path(@prev_page) do
-          %i.c-icon-arrow-left>
-          = @prev_page.name
-      %li.p-item_nav-link_next
-        = link_to item_path(@next_page) do
-          %i.c-icon-arrow-right
-          = @next_page.name
+      - if Item.any?
+        %li.p-item_nav-link_prev
+          = link_to item_path(@prev_page) do
+            %i.c-icon-arrow-left>
+            = @prev_page.name
+        %li.p-item_nav-link_next
+          = link_to item_path(@next_page) do
+            %i.c-icon-arrow-right
+            = @next_page.name
     .c-item_social-media-box
       %ul.c-social-media-box
         %li

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -106,7 +106,7 @@
         %ul.p-item_message_block
           - @comments.each do|message|
             %li.l-clearfix
-              = link_to '#', class: 'p-item_message_user' do
+              = link_to mypage_path(message.user_id), class: 'p-item_message_user' do
                 %figure
                   %div
                     = image_tag 'common/member_photo_noimage_thumb.png'
@@ -159,16 +159,16 @@
     .c-items-in-user-profile
       %section.c-items-box_container.l-clearfix.c-items-box_overflow.c-items-in-user-profile
         %h2.c-items-box_head
-          = link_to '#' do
+          = link_to mypage_path(@item.seller_id) do
             = @seller.nickname + "さんのその他の出品"
         .c-items-box_content.l-clearfix
-          -# = render 'layouts/item',item: @other_items
+          = render partial:'layouts/item',collection: @other_items
       %section.c-items-box_container.l-clearfix.c-items-box_overflow
         %h2.c-items-box_head
-          = link_to '/brand/3117/791/' do
+          = link_to lower_category_path(@item.lower_category_id) do
             = @brand.name + " " + @lower_category.name + " " + "その他の商品"
         .c-items-box_content.l-clearfix
-          -# = render 'layouts/item',item: @other_brand_items
+          = render partial:'layouts/item',collection: @other_brand_items
     #report-item.c-modal.mfp-hide
       .c-modal_inner.c-modal_banner
         .c-modal_body

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -104,29 +104,7 @@
     .p-item_message_container
       .p-item_message_content
         %ul.p-item_message_block
-          - @comments.each do|message|
-            %li.l-clearfix
-              = link_to mypage_path(message.user_id), class: 'p-item_message_user' do
-                %figure
-                  %div
-                    = image_tag 'common/member_photo_noimage_thumb.png'
-                  %figcaption.u-fwBold
-                    = message.user.nickname
-                - if message.user.id == @item.seller.id
-                  .p-item_message_seller 出品者
-              .p-item_message_body
-                .p-item_message_body-text
-                  = message.text
-                .p-item_message_icons.l-clearfix
-                  %time.p-item_message_icon-left
-                    %i.c-icon-time
-                    %span
-                      = time_ago_in_words(message.created_at)+"前"
-                  .p-item_message_icon-right
-                    = form_for '#', html: {class: 'c-message-form'} do |f|
-                      = button_tag '' do
-                        %i.c-icon-flag
-                %i.c-icon-balloon
+          = render partial: "items/comment",collection: @comments
       .p-item_message_content
         = form_for [@item,@comment] , html: {class: 'c-message-form'} do |f|
           %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。


### PR DESCRIPTION
# WHAT
・アイテム詳細ページにて、出品中の他のアイテム（ランダムに表示）に誘導するリンクを
　生成し表示しているが、アイテムが未登録時に読み込まないように処理を加えた。

# WHY

・アイテム詳細ページにて、出品されている他の商品へのリンクをランダムに生成する
　リンクを作成していたが（この段階ではプルリクエスト承認済み）、
　開発中の作業段階にて、他担当者より、アイテム未登録時にエラーが出るとのこと指摘を受け
　便宜上、一旦コメントアウトして作業を行なっていた。

・アイテム未登録の状態で、アイテム詳細ページにユーザーが直接アクセスすること自体は
　考えにくい状況ではあるものの、今回、アイテム未登録時に詳細ページにアクセスした際に
　ランダムリンクを生成するメソッドが発動しないように手を加えた。

# NOTE
上記に加えて、
・ランダムに生成するアイテムidを２種類生成するように修正した
・マイページへのリンク、同ブランド商品へのリンクなどのパスを修正した

以上、よろしくお願いいたします。