### PR TITLE
コメント削除機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@
 |user_id|integer|null:false, foreign_key:true|
 |item_id|integer|null:false, foreign_key:true|
 |text|text|null:false|
+|state|integer|null:false, default:0|
 
 ### Association
 - belongs_to :user

--- a/app/assets/stylesheets/_component.scss
+++ b/app/assets/stylesheets/_component.scss
@@ -1113,3 +1113,6 @@ i {
   text-align: center;
   background-color:#F0FFF0;
 }
+.c-icon-delete{
+  margin-left: 10px;
+}

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -13,7 +13,7 @@ class CommentsController < ApplicationController
 
   def update
     @comment = Comment.find(params[:id])
-    @comment.update(state:"1")
+    @comment.update(state:"deleted")
     redirect_to item_path(@item.id), notice: "コメントを削除しました"
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -11,7 +11,10 @@ class CommentsController < ApplicationController
     redirect_to item_path(@item.id) ,notice: 'メッセージを投稿しました'
   end
 
-  def destroy
+  def update
+    @comment = Comment.find(params[:id])
+    @comment.update(text:"このコメントは削除されました")
+    redirect_to item_path(@item.id), notice: "コメントを削除しました"
   end
 
     private

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -13,7 +13,7 @@ class CommentsController < ApplicationController
 
   def update
     @comment = Comment.find(params[:id])
-    @comment.update(text:"このコメントは削除されました")
+    @comment.update(state:"1")
     redirect_to item_path(@item.id), notice: "コメントを削除しました"
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,4 +3,10 @@ class Comment < ApplicationRecord
   belongs_to :item
 
   validates :text, :user_id, :item_id, presence: true
+
+  enum state: {
+    posting: 0,
+    deleted: 1,
+  }
+
 end

--- a/app/views/items/_comment.html.haml
+++ b/app/views/items/_comment.html.haml
@@ -18,6 +18,9 @@
           = form_for '#', html: {class: 'c-message-form'} do |f|
             = button_tag '' do
               %i.c-icon-flag
+          - if comment.item.seller == current_user
+            = link_to item_comment_path(@item,comment), method: :patch , data: { confirm: "本当に削除しますか？" } do
+              %i.c-icon-delete
       %i.c-icon-balloon
 -else
   %li.l-clearfix
@@ -41,4 +44,7 @@
           = form_for '#', html: {class: 'c-message-form'} do |f|
             = button_tag '' do
               %i.c-icon-flag
+          - if comment.item.seller == current_user
+            = link_to item_comment_path(@item,comment), method: :patch , data: { confirm: "本当に削除しますか？" } do
+              %i.c-icon-delete
       %i.c-icon-balloon

--- a/app/views/items/_comment.html.haml
+++ b/app/views/items/_comment.html.haml
@@ -8,7 +8,7 @@
           = comment.user.nickname
     .p-item_message_body_current-user
       .p-item_message_body-text
-        - if comment.state == 1
+        - if comment.state == "deleted"
           このコメントは削除されました
         - else
           = comment.text
@@ -17,7 +17,7 @@
           %i.c-icon-time
           %span
             = time_ago_in_words(comment.created_at)+"前"
-        - if comment.state == 1
+        - if comment.state == "deleted"
           .p-item_message_icon-right
         - else
           .p-item_message_icon-right
@@ -36,7 +36,7 @@
         .p-item_message_seller 出品者
     .p-item_message_body
       .p-item_message_body-text
-        - if comment.state == 1
+        - if comment.state == "deleted"
           このコメントは削除されました
         - else
           = comment.text
@@ -45,7 +45,7 @@
           %i.c-icon-time
           %span
             = time_ago_in_words(comment.created_at)+"前"
-        - if comment.state == 1
+        - if comment.state == "deleted"
           .p-item_message_icon-right
         - else
           .p-item_message_icon-right

--- a/app/views/items/_comment.html.haml
+++ b/app/views/items/_comment.html.haml
@@ -8,19 +8,25 @@
           = comment.user.nickname
     .p-item_message_body_current-user
       .p-item_message_body-text
-        = comment.text
+        - if comment.state == 1
+          このコメントは削除されました
+        - else
+          = comment.text
       .p-item_message_icons_current-user.l-clearfix
         %time.p-item_message_icon-left
           %i.c-icon-time
           %span
             = time_ago_in_words(comment.created_at)+"前"
-        .p-item_message_icon-right
-          = form_for '#', html: {class: 'c-message-form'} do |f|
-            = button_tag '' do
-              %i.c-icon-flag
-          - if comment.item.seller == current_user
-            = link_to item_comment_path(@item,comment), method: :patch , data: { confirm: "本当に削除しますか？" } do
-              %i.c-icon-delete
+        - if comment.state == 1
+          .p-item_message_icon-right
+        - else
+          .p-item_message_icon-right
+            = form_for '#', html: {class: 'c-message-form'} do |f|
+              = button_tag '' do
+                %i.c-icon-flag
+            - if comment.item.seller == current_user
+              = link_to item_comment_path(@item,comment), method: :patch , data: { confirm: "本当に削除しますか？" } do
+                %i.c-icon-delete
       %i.c-icon-balloon
 -else
   %li.l-clearfix
@@ -34,17 +40,23 @@
         .p-item_message_seller 出品者
     .p-item_message_body
       .p-item_message_body-text
-        = comment.text
+        - if comment.state == 1
+          このコメントは削除されました
+        - else
+          = comment.text
       .p-item_message_icons.l-clearfix
         %time.p-item_message_icon-left
           %i.c-icon-time
           %span
             = time_ago_in_words(comment.created_at)+"前"
-        .p-item_message_icon-right
-          = form_for '#', html: {class: 'c-message-form'} do |f|
-            = button_tag '' do
-              %i.c-icon-flag
-          - if comment.item.seller == current_user
-            = link_to item_comment_path(@item,comment), method: :patch , data: { confirm: "本当に削除しますか？" } do
-              %i.c-icon-delete
+        - if comment.state == 1
+          .p-item_message_icon-right
+        - else
+          .p-item_message_icon-right
+            = form_for '#', html: {class: 'c-message-form'} do |f|
+              = button_tag '' do
+                %i.c-icon-flag
+            - if comment.item.seller == current_user
+              = link_to item_comment_path(@item,comment), method: :patch , data: { confirm: "本当に削除しますか？" } do
+                %i.c-icon-delete
       %i.c-icon-balloon

--- a/app/views/items/_comment.html.haml
+++ b/app/views/items/_comment.html.haml
@@ -21,9 +21,8 @@
           .p-item_message_icon-right
         - else
           .p-item_message_icon-right
-            - if comment.item.seller == current_user
-              = link_to item_comment_path(@item,comment), method: :patch , data: { confirm: "本当に削除しますか？" } do
-                %i.c-icon-delete
+            = link_to item_comment_path(@item,comment), method: :patch , data: { confirm: "本当に削除しますか？" } do
+              %i.c-icon-delete
       %i.c-icon-balloon
 -else
   %li.l-clearfix

--- a/app/views/items/_comment.html.haml
+++ b/app/views/items/_comment.html.haml
@@ -21,9 +21,6 @@
           .p-item_message_icon-right
         - else
           .p-item_message_icon-right
-            = form_for '#', html: {class: 'c-message-form'} do |f|
-              = button_tag '' do
-                %i.c-icon-flag
             - if comment.item.seller == current_user
               = link_to item_comment_path(@item,comment), method: :patch , data: { confirm: "本当に削除しますか？" } do
                 %i.c-icon-delete

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -159,5 +159,5 @@
           .c-modal_head.u-fwBold 確認
           不適切な商品を報告しますか？
         .l-clearfix
-          .c-modal_btn.c-modal_btn-cancel.js-modal_btn-cancel キャンセル
-          = link_to 'はい',new_item_report_path(@item), {class: 'c-modal_btn c-modal_btn-submit',method: :get}
+          %a.c-modal_btn.c-modal_btn-cancel.js-modal_btn-cancel{style: :"text-decoration:none;"} キャンセル
+          = link_to 'はい',new_item_report_path(@item), {class: 'c-modal_btn c-modal_btn-submit',method: :get, style: :"text-decoration:none;"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
     resources :reviews, only: [:new, :create]
     resources :reports, only: [:new, :create, :destroy]
     resources :likes, only: [:create, :destroy]
-    resources :comments, only: [:create, :destroy]
+    resources :comments, only: [:create, :update]
     resources :transaction_messages, only: [:index, :create]
     resource :buy, only: [:edit,:update]
     resources :information, only: [:create]

--- a/db/migrate/20190303063628_add_state_to_comments.rb
+++ b/db/migrate/20190303063628_add_state_to_comments.rb
@@ -1,0 +1,5 @@
+class AddStateToComments < ActiveRecord::Migration[5.1]
+  def change
+    add_column :comments, :state, :integer , null:false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190214144942) do
+ActiveRecord::Schema.define(version: 20190303063628) do
 
   create_table "addresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "first_name", default: "", null: false
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 20190214144942) do
     t.text "text", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "state", default: 0, null: false
     t.index ["item_id"], name: "index_comments_on_item_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
@@ -84,9 +85,11 @@ ActiveRecord::Schema.define(version: 20190214144942) do
     t.integer "point", default: 0
     t.bigint "stakeholder_id"
     t.bigint "related_item_id"
+    t.bigint "created_review_id"
     t.boolean "unread_or_read", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["created_review_id"], name: "index_information_on_created_review_id"
     t.index ["related_item_id"], name: "index_information_on_related_item_id"
     t.index ["stakeholder_id"], name: "index_information_on_stakeholder_id"
   end


### PR DESCRIPTION
# WHAT

・投稿された「商品へのコメント」を削除する機能を追加した

# WHY

・投稿された「商品へのコメント」について、以下のニーズに対応するため
　１）コメント投稿後に、コメントを取り消したい場合（投稿者判断での削除）
　２）不適切なコメントの削除（出品者判断での削除）
　３）取引完了後のプライバシーを考慮したコメント削除（出品者判断での削除）

・尚、コメントの削除ができる権限を以下の通りとした
　１）出品者（当該出品ページの管理者）は、全てのコメントを削除する権限を持つ
　２）コメントの投稿者は、自身が投稿したコメントにのみ削除する権限を持つ
　３）上記以外のユーザーは、いかなる場合もコメントを削除できない

# ポイント

・見本サイトの仕様では、コメント削除後にもコメント表示欄（吹き出し）は残したまま、
　コメントの内容が「このコメントは削除されました」とのメッセージに変更される。
　意図的にコメント投稿が行われた形跡を残る仕様となっている。

・上記から、コメントデータをdbから削除するのではなく、コメントデータを保持しつつも、
　表示を切り替えるという方法を取られていると推測できる。

・コメント削除後に、ユーザーの要望に応じて再表示することができるようにするため、
　また、不適切なコメント等があった際に、その記録を保持する必要があるため、
　といった理由が考えられる。

・上記に対して以下の対応を実装した

１）commentsテーブルに新たにstateカラムを追加した（初期値：0）
２）削除ボタンをクリック→削除しますか？の確認を表示→「OK」で処理実行
３）２）を実行するとupdateメソッドによってstateカラムに「1」を付与し、
　　当該コメントは削除されたものとして区別する
４）削除済みと判断されたコメントは、コメント欄に「削除されました」と表示する
　　削除されたコメントの吹き出し内からは不要なアイコンは取り除いた
５）削除ボタン（ゴミ箱）の表示・非表示を条件分岐で分けた
　　（出品者（当該出品ページ管理者）並びに、当該コメントの投稿者のみに表示）

※「app/views/items/show.html.haml」ファイルの「不適切な商品の報告」モーダルの修正は、
　style: :"text-decoration:none;"によってリンクの下線を取り除いた
　今回の実装とは関係がありません。