### PR TITLE
「問題のあるコメントの報告」機能の実装

### DIFF
--- a/app/assets/stylesheets/_report.scss
+++ b/app/assets/stylesheets/_report.scss
@@ -134,3 +134,6 @@
     }
   }
 }
+.form__group--issue {
+    margin-top: 20px 0 0;
+  }

--- a/app/controllers/report_comments_controller.rb
+++ b/app/controllers/report_comments_controller.rb
@@ -1,0 +1,36 @@
+class ReportCommentsController < ApplicationController
+
+  layout "single"
+  before_action :set_item
+  before_action :set_comment
+  before_action :move_to_sign_in
+  before_action :confirm_buyer_already_create_report, only: [:create]
+
+  def new
+    @report_comment = ReportComment.new
+  end
+
+  def create
+    @report_comment = ReportComment.new(user_id: current_user.id, comment_id: params[:comment_id],report_type: params[:report_comment][:report_type],issue: params[:report_comment][:issue])
+    if @report_comment.save
+      redirect_to item_path(@item), notice: "不適切なコメントを報告しました"
+    else
+      redirect_to new_item_comment_report_comment_path(@item,@comment),notice:"違反の種類の選択/お問い合わせ内容を記入して下さい"
+    end
+  end
+
+  def destroy
+    ReportComment.find_by(user_id: current_user.id, comment_id: params[:comment_id]).destroy
+  end
+
+private
+
+  def set_comment
+    @comment = Comment.find(params[:comment_id])
+  end
+
+  def confirm_buyer_already_create_report
+    redirect_to item_path(@item), notice: "既に報告済みです" if @comment.report_comments.exists?(user_id: current_user.id)
+  end
+
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,6 +1,7 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :item
+  has_many :report_comments, dependent: :destroy
 
   validates :text, :user_id, :item_id, presence: true
 

--- a/app/models/report_comment.rb
+++ b/app/models/report_comment.rb
@@ -1,0 +1,19 @@
+class ReportComment < ApplicationRecord
+
+  belongs_to :user
+  belongs_to :comment
+
+  validates :user_id, :comment_id, :report_type, :issue, presence: true
+
+  enum report_type: {
+    violent_language_and_intimidation: 1,
+    slander: 2,
+    direct_trading_and_exchange: 3,
+    publication_of_private_information: 4,
+    induction_to_external_site: 5,
+    others: 6
+  }
+
+end
+
+

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
   has_many :reports, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_many :report_comments, dependent: :destroy
   has_many :transaction_messages, dependent: :destroy
   has_many :addresses, dependent: :destroy
   has_many :avatars, dependent: :destroy, inverse_of: :user

--- a/app/views/items/_comment.html.haml
+++ b/app/views/items/_comment.html.haml
@@ -49,9 +49,8 @@
           .p-item_message_icon-right
         - else
           .p-item_message_icon-right
-            = form_for '#', html: {class: 'c-message-form'} do |f|
-              = button_tag '' do
-                %i.c-icon-flag
+            = link_to new_item_comment_report_comment_path(@item,comment),html: {class: 'c-message-form'} do
+              %i.c-icon-flag
             - if comment.item.seller == current_user
               = link_to item_comment_path(@item,comment), method: :patch , data: { confirm: "本当に削除しますか？" } do
                 %i.c-icon-delete

--- a/app/views/report_comments/new.html.haml
+++ b/app/views/report_comments/new.html.haml
@@ -1,0 +1,22 @@
+.l-single_wrapper
+  %section.report__container
+    %h2.report__head 不適切なコメントの報告
+    .report__inner
+      .report__content
+        = form_for [@item ,@comment, @report_comment] , method: :post do |f|
+          .form__group
+            %label{for:'report_type'} 違反の種類
+            %span.form__require 必須
+            .form__select--wrap
+              = f.select :report_type,ReportComment.report_types_i18n.keys.map {|k| [ReportComment.report_types_i18n[k], k]},{prompt: "選択して下さい"},{class: "form__select--default"}
+          .form__group
+            %label{for:'issue'} お問い合わせ内容
+            = f.text_area :issue, class: "c-textarea-default"
+          .form__flash
+            = flash[:notice]
+          %p.form__info-text 不適切なコメントに基づいて随時、事務局でチェックさせていただき対応してまいります。特に返信はいたしませんが、ご了承ください。
+          = f.submit '送信する',class:"btn__default btn__red"
+
+
+
+

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -39,6 +39,14 @@ ja:
         other_services_or_direct_transactions_or_exchange: "他サービス誘導・直接取引・交換"
         publicity_or_searching: "宣伝・捜し物・福袋"
         other: "その他"
+    report_comment:
+      report_type:
+        violent_language_and_intimidation: "暴言脅迫"
+        slander: "誹謗中傷"
+        direct_trading_and_exchange: "直接取引交換半交換"
+        publication_of_private_information: "個人情報の公開"
+        induction_to_external_site: "外部サイトへの誘導"
+        others: "その他"
   datetime:
     distance_in_words:
       half_a_minute: "30秒前後"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Rails.application.routes.draw do
+  get 'report_comments/new'
+
+  get 'report_comments/create'
+
+  get 'report_comments/destroy'
+
   get 'descriptions/show'
 
   root 'items#index'
@@ -19,7 +25,9 @@ Rails.application.routes.draw do
     resources :reviews, only: [:create]
     resources :reports, only: [:new, :create, :destroy]
     resources :likes, only: [:create, :destroy]
-    resources :comments, only: [:create, :update]
+    resources :comments, only: [:create, :update] do
+      resources :report_comments, only: [:new, :create, :destroy]
+    end
     resources :transaction_messages, only: [:index, :create]
     resource :buy, only: [:edit,:update]
     resources :information, only: [:create]

--- a/db/migrate/20190305125122_create_report_comments.rb
+++ b/db/migrate/20190305125122_create_report_comments.rb
@@ -1,0 +1,11 @@
+class CreateReportComments < ActiveRecord::Migration[5.1]
+  def change
+    create_table :report_comments do |t|
+      t.references :user, foreign_key: true, null:false
+      t.references :comment, foreign_key: true, null:false
+      t.integer :report_type, null:false, default: 0
+      t.text :issue, null:false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190303063628) do
+ActiveRecord::Schema.define(version: 20190305125122) do
 
   create_table "addresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "first_name", default: "", null: false
@@ -170,6 +170,17 @@ ActiveRecord::Schema.define(version: 20190303063628) do
     t.index ["item_id"], name: "index_pictures_on_item_id"
   end
 
+  create_table "report_comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.bigint "user_id", null: false
+    t.bigint "comment_id", null: false
+    t.integer "report_type", default: 0, null: false
+    t.text "issue", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["comment_id"], name: "index_report_comments_on_comment_id"
+    t.index ["user_id"], name: "index_report_comments_on_user_id"
+  end
+
   create_table "reports", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "user_id", null: false
     t.bigint "item_id", null: false
@@ -295,6 +306,8 @@ ActiveRecord::Schema.define(version: 20190303063628) do
   add_foreign_key "middle_categories", "upper_categories"
   add_foreign_key "phone_numbers", "users"
   add_foreign_key "pictures", "items"
+  add_foreign_key "report_comments", "comments"
+  add_foreign_key "report_comments", "users"
   add_foreign_key "reports", "items"
   add_foreign_key "reports", "users"
   add_foreign_key "reviews", "items"


### PR DESCRIPTION
# WHAT
・問題のあるコメント（商品詳細画面）を報告する機能を実装した

# WHY
・誹謗中傷や直接取引などの規約違反となるコメントを報告していただ機能を実装し、
　規約違反や問題の発生を防止するため。

# ポイント
・報告は第三者のコメントのみ（自身のコメントは報告できない）
・報告の種類（report_type：リスト選択）はenumで対応した
・報告の種類（report_type：リスト選択）と、問題の内容（issue：テキスト入力）の両方が
　入力されていないと登録不可とした